### PR TITLE
Add travis build matrix to test against different Plone versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - PLONE_VERSION=4.1.6
     - PLONE_VERSION=4.2.7
     - PLONE_VERSION=4.3.4
+    - PLONE_VERSION=5.0a3
 
 install:
   - sed -ie "s/^plone.version.*/plone.version = $PLONE_VERSION/g" test_answers.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ env:
     - PLONE_VERSION=4.3.4
     - PLONE_VERSION=5.0a3
 
+matrix:
+  allow_failures:
+    - env: PLONE_VERSION=4.0.10
+
 install:
   - sed -ie "s/^plone.version.*/plone.version = $PLONE_VERSION/g" test_answers.ini
   - python bootstrap-buildout.py --setuptools-version=8.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,14 @@ cache:
   directories:
   - test.plone_addon/eggs
 
+env:
+  matrix:
+    - PLONE_VERSION=4.1.6
+    - PLONE_VERSION=4.2.7
+    - PLONE_VERSION=4.3.4
+
 install:
+  - sed -ie "s/^plone.version.*/plone.version = $PLONE_VERSION/g" test_answers.ini
   - python bootstrap-buildout.py --setuptools-version=8.3
   - bin/buildout
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
 
 env:
   matrix:
+    - PLONE_VERSION=4.0.10
     - PLONE_VERSION=4.1.6
     - PLONE_VERSION=4.2.7
     - PLONE_VERSION=4.3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
 matrix:
   allow_failures:
     - env: PLONE_VERSION=4.0.10
+    - env: PLONE_VERSION=4.1.6
+    - env: PLONE_VERSION=4.2.7
 
 install:
   - sed -ie "s/^plone.version.*/plone.version = $PLONE_VERSION/g" test_answers.ini

--- a/bobtemplates/plone_addon/buildout.cfg.bob
+++ b/bobtemplates/plone_addon/buildout.cfg.bob
@@ -1,28 +1,20 @@
 [buildout]
-package-name = {{{ package.dottedname }}}
-package-extras = [test]
-
-extends =
-    https://raw.github.com/collective/buildout.plonetest/master/plone-4.3.x.cfg
-    https://raw.github.com/collective/buildout.plonetest/master/qa.cfg
+extends = http://dist.plone.org/release/{{{ plone.version }}}/versions.cfg
+extensions = mr.developer
 parts =
-    createcoverage
-    omelette
+    instance
     test
-    robot
     code-analysis
-show-picked-versions = true
-
 develop = .
 
+[instance]
+recipe = plone.recipe.zope2instance
+user = admin:admin
+http-address = 8080
 eggs =
+    Plone
     Pillow
-    plone.reload
-    Products.PDBDebugMode
-    Products.DocFinderTab
-    aws.zope2zcmldoc
-    collective.profiler
-
+    {{{ package.dottedname }}} [test]
 
 [code-analysis]
 recipe = plone.recipe.codeanalysis
@@ -33,16 +25,14 @@ flake8-max-complexity = 15
 
 [omelette]
 recipe = collective.recipe.omelette
-eggs = ${buildout:eggs}
-
+eggs = ${instance:eggs}
 
 {{% if package.testing %}}
+
 [test]
 recipe = zc.recipe.testrunner
-eggs =
-    ${buildout:eggs}
-    ${buildout:package-name} ${buildout:package-extras}
-defaults = ['-s', '${buildout:package-name}', '--auto-color', '--auto-progress']
+eggs = ${instance:eggs}
+defaults = ['-s', '{{{ package.dottedname }}}', '--auto-color', '--auto-progress']
 
 
 [robot]

--- a/travis.cfg
+++ b/travis.cfg
@@ -4,4 +4,5 @@ parts += code-analysis
 
 [code-analysis]
 recipe = plone.recipe.codeanalysis
+pre-commit-hook = False
 return-status-codes = True


### PR DESCRIPTION
Simplify buildout, do not rely on buildout.plonetest, do not create pre-commit hook on travis.