### PR TITLE
WIP idea for extending

### DIFF
--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/more_templates/contenttype/interfaces.py.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/more_templates/contenttype/interfaces.py.bob
@@ -1,0 +1,14 @@
+from zope import schema
+from zope.interface import Interface
+from {{{ package.dottedname }}} import _
+
+class IThing(Interface):
+    title = schema.TextLine(
+        title=_(u"Title"),
+        required=True,
+    )
+
+    description = schema.Text(
+        title=_(u"Description"),
+        required=False,
+    )

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/more_templates/contenttype/profiles/default/types.xml
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/more_templates/contenttype/profiles/default/types.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="portal_types" meta_type="Plone Types Tool">
+  <!-- For each content type, you create a new files types/{{{ name }}}.xml
+       Then you create a new entry below, where the attribute name must match
+       {{{ name }}} from above. The other other attribute you will only modify
+       if you do something non dexterity like -->
+  <object name="thing" meta_type="Dexterity FTI"/>
+</object>

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/more_templates/contenttype/profiles/default/types/thing.xml
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/more_templates/contenttype/profiles/default/types/thing.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<object name="thing" meta_type="Dexterity FTI" i18n:domain="plone"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="title" i18n:translate="">Thing</property>
+ <property name="description" i18n:translate="">None</property>
+ <property name="icon_expr">string:${portal_url}/document_icon.png</property>
+ <property name="factory">thing</property>
+ <property name="add_view_expr">string:${folder_url}/++add++thing</property>
+ <property name="link_target"></property>
+ <property name="immediate_view">view</property>
+ <property name="global_allow">True</property>
+ <property name="filter_content_types">True</property>
+ <property name="allowed_content_types"/>
+ <property name="allow_discussion">False</property>
+ <property name="default_view">view</property>
+ <property name="view_methods">
+  <element value="view"/>
+ </property>
+ <property name="default_view_fallback">False</property>
+ <property name="add_permission">cmf.AddPortalContent</property>
+<!--
+ <property name="klass">plone.dexterity.content.Item</property>
+-->
+ <property name="klass">plone.dexterity.content.Container</property>
+ <property name="behaviors">
+  <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
+  <element value="plone.app.content.interfaces.INameFromTitle"/>
+ </property>
+ <property name="schema">{{{ package.dottedname }}}.interfaces.IThing</property>
+ <property name="model_source"></property>
+ <property name="model_file"></property>
+ <property name="schema_policy">dexterity</property>
+ <alias from="(Default)" to="(dynamic view)"/>
+ <alias from="edit" to="@@edit"/>
+ <alias from="sharing" to="@@sharing"/>
+ <alias from="view" to="(selected layout)"/>
+ <action title="View" action_id="view" category="object" condition_expr=""
+    description="" icon_expr="" link_target="" url_expr="string:${object_url}"
+    visible="True">
+  <permission value="View"/>
+ </action>
+ <action title="Edit" action_id="edit" category="object" condition_expr=""
+    description="" icon_expr="" link_target=""
+    url_expr="string:${object_url}/edit" visible="True">
+  <permission value="Modify portal content"/>
+ </action>
+</object>

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/more_templates/contenttype/tests/test_thing.py.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/more_templates/contenttype/tests/test_thing.py.bob
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+from plone.app.testing import setRoles
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.testing import TEST_USER_ID
+from plone.dexterity.interfaces import IDexterityFTI
+from plone.testing.z2 import Browser
+from {{{ package.dottedname }}}.interfaces import IThing
+from {{{ package.dottedname }}}.testing import {{{package.uppercasename}}}_FUNCTIONAL_TESTING  # noqa
+from {{{ package.dottedname }}}.testing import {{{package.uppercasename}}}_FUNCTIONAL_TESTING  # noqa
+from zope.component import createObject
+from zope.component import queryUtility
+import unittest
+
+
+class ThingIntegrationTest(unittest.TestCase):
+
+    layer = {{{package.uppercasename}}}_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+    def test_schema(self):
+        fti = queryUtility(IDexterityFTI, name='Thing')
+        schema = fti.lookupSchema()
+        self.assertEqual(IThing, schema)
+
+    def test_fti(self):
+        fti = queryUtility(IDexterityFTI, name='Thing')
+        self.assertTrue(fti)
+
+    def test_factory(self):
+        fti = queryUtility(IDexterityFTI, name='Thing')
+        factory = fti.factory
+        thing = createObject(factory)
+        self.assertTrue(IThing.providedBy(thing))
+
+    def test_adding(self):
+        self.portal.invokeFactory('Thing', 'thing')
+        self.assertTrue(IThing.providedBy(self.portal.thing))
+
+
+class ThingFunctionalTest(unittest.TestCase):
+
+    layer = {{{package.uppercasename}}}_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        app = self.layer['app']
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        self.portal_url = self.portal.absolute_url()
+
+        # Set up browser
+        self.browser = Browser(app)
+        self.browser.handleErrors = False
+        self.browser.addHeader(
+            'Authorization',
+            'Basic %s:%s' % (SITE_OWNER_NAME, SITE_OWNER_PASSWORD,)
+        )
+
+    def test_add_thing(self):
+        self.browser.open(self.portal_url + '/++add++Thing')
+        self.browser.getControl(name="form.widgets.title").value = \
+            "My Thing"
+        self.browser.getControl(name="form.widgets.description")\
+            .value = "This is my thing"
+        self.browser.getControl("Save").click()
+
+        self.assertEqual(
+            self.portal['my-thing'].title,
+            "My Thing"
+        )
+
+    def test_view_thing(self):
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        self.portal.invokeFactory(
+            "Thing",
+            id="my-thing",
+            title="My Thing",
+        )
+
+        import transaction
+        transaction.commit()
+
+        self.browser.open(self.portal_url + '/my-thing')
+
+        self.assertTrue('My Thing' in self.browser.contents)


### PR DESCRIPTION
When one creates a package, it is not always clear, what code is needed.
This PR proposes the idea of providing a bunch of example code that can be copied/appended to the existing package.
they reside in a directory that is not imported in any way and can be excluded in Metadata.in so that it also won't exist as dead code in eggs.
What is still missing is a simple shell script or make file that can copy new files and append content to existing files. Appended files still need clean up. Which files need clean up a code-analysis run would show (Except for zcml... :disappointed:)

This is open for discussion, if you don't like it, please provide ideas for alternatives.
I am looking for templates to include

- a viewlet
- a portlet
- a view
- a css file
- a js file
- a contenrule
- a behavior
- an event handler
- a browser view to be used as conditions in tal statements (for workflows, for example)
- memberdata extensions
- custom indexer
- placeful workflows
- registry and control panel views
- new roles

I think these are common use cases. Common to those use cases is that you won't know of all of them that you need them at the start of the project. Common to most of them is that you might not be aware of the current best practices on how to integrate AND test them.
