### PR TITLE
use PloneWithPackageLayer, testing.zcml and testing profile

### DIFF
--- a/bobtemplates/plone_addon/buildout.cfg.bob
+++ b/bobtemplates/plone_addon/buildout.cfg.bob
@@ -16,6 +16,7 @@ eggs =
     Plone
     Pillow
     {{{ package.dottedname }}} [test]
+zcml = {{{ package.dottedname }}}-testing
 
 
 [code-analysis]

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/testing/metadata.xml.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/testing/metadata.xml.bob
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>1000</version>
+  <dependencies>
+    <dependency>profile-{{{ package.dottedname }}}:default</dependency>
+  </dependencies>
+</metadata>

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/setuphandlers.py.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/setuphandlers.py.bob
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
 
-def isNotCurrentProfile(context):
-    return context.readDataFile('{{{ package.longname }}}_marker.txt') is None
+def isNotCurrentProfile(context, marker='marker'):
+    filename = '{{{ package.longname }}}_{}.txt'.format(marker)
+    return context.readDataFile(filename) is None
 
 
 def post_install(context):
@@ -10,3 +11,10 @@ def post_install(context):
     if isNotCurrentProfile(context):
         return
     # Do something during the installation of this package
+
+
+def test_fixture(context):
+    """Test fixture setup"""
+    if isNotCurrentProfile(context, 'testing'):
+        return
+    # Do something for test fixture

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/testing.py.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/testing.py.bob
@@ -3,40 +3,24 @@
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
 {{% endif %}}
 from plone.app.robotframework.testing import REMOTE_LIBRARY_BUNDLE_FIXTURE
-from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
-{{% if not plone.is_plone5 %}}
-from plone.app.testing import PLONE_FIXTURE
-{{% endif %}}
-from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import PloneWithPackageLayer
 from plone.testing import z2
-from zope.configuration import xmlconfig
 
 import {{{ package.dottedname }}}
 
 
-class {{{ package.browserlayer }}}(PloneSandboxLayer):
-
+{{{package.uppercasename}}}_FIXTURE = PloneWithPackageLayer(
 {{% if plone.is_plone5 %}}
-    defaultBases = (PLONE_APP_CONTENTTYPES_FIXTURE,)
+    bases=(PLONE_APP_CONTENTTYPES_FIXTURE, ),
 {{% endif %}}
-{{% if not plone.is_plone5 %}}
-    defaultBases = (PLONE_FIXTURE,)
-{{% endif %}}
-
-    def setUpZope(self, app, configurationContext):
-        xmlconfig.file(
-            'configure.zcml',
-            {{{ package.dottedname }}},
-            context=configurationContext
-        )
-
-    def setUpPloneSite(self, portal):
-        applyProfile(portal, '{{{ package.dottedname }}}:default')
-
-
-{{{package.uppercasename}}}_FIXTURE = {{{ package.browserlayer }}}()
+    zcml_package={{{ package.dottedname }}},
+    zcml_filename='testing.zcml',
+    gs_profile_id='{{{ package.dottedname }}}:testing',
+    name='{{{ package.browserlayer }}}',
+    additional_z2_products=()
+)
 
 
 {{{package.uppercasename}}}_INTEGRATION_TESTING = IntegrationTesting(

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/testing.zcml.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/testing.zcml.bob
@@ -1,0 +1,25 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:five="http://namespaces.zope.org/five"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="{{{ package.dottedname }}}">
+
+    <include file="configure.zcml" />
+
+    <genericsetup:registerProfile
+        name="testing"
+        title="{{{ package.dottedname }}} tests"
+        directory="profiles/testing"
+        description="Installs the tests fixture for {{{ package.dottedname }}} add-on."
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+    
+    <genericsetup:importStep
+        name="{{{ package.dottedname }}}-testFixture"
+        title="{{{ package.dottedname }}} test_fixture import step"
+        description="Test fixture import step from {{{ package.dottedname }}}"
+        handler=".setuphandlers.test_fixture">
+    </genericsetup:importStep>
+
+</configure>

--- a/tests.py
+++ b/tests.py
@@ -87,8 +87,12 @@ class PloneTemplateTest(BaseTemplateTest):
                 self.project + '/src/collective/foo/profiles/default/browserlayer.xml',  # noqa
                 self.project + '/src/collective/foo/profiles/default/collectivefoo_marker.txt',  # noqa
                 self.project + '/src/collective/foo/profiles/default/metadata.xml',  # noqa
+                self.project + '/src/collective/foo/profiles/testing',
+                self.project + '/src/collective/foo/profiles/testing/collectivefoo_testing.txt',  # noqa
+                self.project + '/src/collective/foo/profiles/testing/metadata.xml',  # noqa
                 self.project + '/src/collective/foo/setuphandlers.py',
                 self.project + '/src/collective/foo/testing.py',
+                self.project + '/src/collective/foo/testing.zcml',
                 self.project + '/src/collective/foo/tests',
                 self.project + '/src/collective/foo/tests/__init__.py',
                 self.project + '/src/collective/foo/tests/robot',
@@ -153,8 +157,12 @@ class PloneTemplateTest(BaseTemplateTest):
                 self.project + '/src/collective/foo/bar/profiles/default/browserlayer.xml',  # noqa
                 self.project + '/src/collective/foo/bar/profiles/default/collectivefoobar_marker.txt',  # noqa
                 self.project + '/src/collective/foo/bar/profiles/default/metadata.xml',  # noqa
+                self.project + '/src/collective/foo/bar/profiles/testing',
+                self.project + '/src/collective/foo/bar/profiles/testing/collectivefoobar_testing.txt',  # noqa
+                self.project + '/src/collective/foo/bar/profiles/testing/metadata.xml',  # noqa
                 self.project + '/src/collective/foo/bar/setuphandlers.py',
                 self.project + '/src/collective/foo/bar/testing.py',
+                self.project + '/src/collective/foo/bar/testing.zcml',
                 self.project + '/src/collective/foo/bar/tests',
                 self.project + '/src/collective/foo/bar/tests/__init__.py',
                 self.project + '/src/collective/foo/bar/tests/robot',


### PR DESCRIPTION
Setting up fixture this way  enables to test the fixture TTW
with a zope instance started with testing.zcml loaded.

This does not impact the standard use of the add-on.