### PR TITLE
Relax coverage checking on namespace's __init__.py

### DIFF
--- a/bobtemplates/plone_addon/src/+package.namespace+/__init__.py
+++ b/bobtemplates/plone_addon/src/+package.namespace+/__init__.py
@@ -2,6 +2,6 @@
 # See http://peak.telecommunity.com/DevCenter/setuptools#namespace-packages
 try:
     __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-    from pkgutil import extend_path
-    __path__ = extend_path(__path__, __name__)
+except ImportError:                                         # pragma: no cover
+    from pkgutil import extend_path                         # pragma: no cover
+    __path__ = extend_path(__path__, __name__)              # pragma: no cover


### PR DESCRIPTION
New branch to replace #70, which got mangled.

This helps if running coverage on the generated egg

See [what plone.api does](https://github.com/plone/plone.api/blob/master/src/plone/__init__.py)