### PR TITLE
fix issue #81 space in names breaks generated packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 0.12 (unreleased)
 -----------------
 
+- Added support for Dexterity content types with spaces in their names
+  [pigeonflight]
+
 - Fix #84 Make travis cache the egg directory of the generated package.
   [jensens]
 
@@ -12,6 +15,7 @@ Changelog
 
 - Remove unittest2 dependency.
   [gforcada]
+
 
 0.11 (2015-07-24)
 -----------------

--- a/bobtemplates/hooks.py
+++ b/bobtemplates/hooks.py
@@ -185,10 +185,11 @@ def prepare_render(configurator):
 
     if configurator.variables.get('package.dexterity_type_name'):
         dexterity_type_name = configurator.variables[
-                            'package.dexterity_type_name']
+            'package.dexterity_type_name']
         configurator.variables[
-                            'package.dexterity_type_name'
-               ] = dexterity_type_name.replace(' ', '').replace('_', '')
+            'package.dexterity_type_name'
+            ] = dexterity_type_name.replace(' ', '')\
+            .replace('_', '')
         configurator.variables[
             'package.dexterity_type_name_lower'
         ] = configurator.variables['package.dexterity_type_name'].lower()

--- a/bobtemplates/hooks.py
+++ b/bobtemplates/hooks.py
@@ -191,8 +191,9 @@ def prepare_render(configurator):
             ] = dexterity_type_name.replace(' ', '')\
             .replace('_', '')
         configurator.variables[
-                            'package.dexterity_type_name'
-               ] = dexterity_type_name.replace(' ', '').replace('_', '')
+            'package.dexterity_type_name'
+            ] = dexterity_type_name.replace(' ', '')\
+            .replace('_', '')
         configurator.variables[
             'package.dexterity_type_name_lower'
         ] = configurator.variables['package.dexterity_type_name'].lower()

--- a/bobtemplates/hooks.py
+++ b/bobtemplates/hooks.py
@@ -184,12 +184,6 @@ def prepare_render(configurator):
     configurator.variables['package.namespace_packages'] = namespace_packages
 
     if configurator.variables.get('package.dexterity_type_name'):
-        dexterity_type_name = configurator.variables[
-            'package.dexterity_type_name']
-        configurator.variables[
-            'package.dexterity_type_name'
-            ] = dexterity_type_name.replace(' ', '')\
-            .replace('_', '')
         configurator.variables[
             'package.dexterity_type_name'
             ] = dexterity_type_name.replace(' ', '')\

--- a/bobtemplates/hooks.py
+++ b/bobtemplates/hooks.py
@@ -191,6 +191,9 @@ def prepare_render(configurator):
             ] = dexterity_type_name.replace(' ', '')\
             .replace('_', '')
         configurator.variables[
+                            'package.dexterity_type_name'
+               ] = dexterity_type_name.replace(' ', '').replace('_', '')
+        configurator.variables[
             'package.dexterity_type_name_lower'
         ] = configurator.variables['package.dexterity_type_name'].lower()
     else:

--- a/bobtemplates/hooks.py
+++ b/bobtemplates/hooks.py
@@ -184,6 +184,11 @@ def prepare_render(configurator):
     configurator.variables['package.namespace_packages'] = namespace_packages
 
     if configurator.variables.get('package.dexterity_type_name'):
+        dexterity_type_name = configurator.variables[
+                            'package.dexterity_type_name']
+        configurator.variables[
+                            'package.dexterity_type_name'
+               ] = dexterity_type_name.replace(' ', '').replace('_', '')
         configurator.variables[
             'package.dexterity_type_name_lower'
         ] = configurator.variables['package.dexterity_type_name'].lower()


### PR DESCRIPTION
This fix ensures that if someone gives a dexterity content a name with a space in it, the internal (hooks.py) code removes spaces from the resulting name.