### PR TITLE
Remove unittest2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 - Update tests to use Plone 5.0b3.
   [jensens]
 
+- Remove unittest2 dependency.
+  [gforcada]
 
 0.11 (2015-07-24)
 -----------------

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/tests/test_setup.py.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/tests/test_setup.py.bob
@@ -3,7 +3,7 @@
 from {{{ package.dottedname }}}.testing import {{{package.uppercasename}}}_INTEGRATION_TESTING  # noqa
 from plone import api
 
-import unittest2 as unittest
+import unittest
 
 
 class TestSetup(unittest.TestCase):


### PR DESCRIPTION
Since Python 2.7 unittest2 is merged on python itself.