### PR TITLE
Enabled robot part in generated package.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 0.12 (unreleased)
 -----------------
 
+- Enabled robot part in generated package.
+  [maurits]
+
 - Fix #84 Make travis cache the egg directory of the generated package.
   [jensens]
 

--- a/bobtemplates/plone_addon/.gitignore.bob
+++ b/bobtemplates/plone_addon/.gitignore.bob
@@ -18,3 +18,5 @@ htmlcov/
 *.log
 output.xml
 *.swp
+log.html
+report.html

--- a/bobtemplates/plone_addon/buildout.cfg.bob
+++ b/bobtemplates/plone_addon/buildout.cfg.bob
@@ -8,6 +8,7 @@ parts =
     releaser
     i18ndude
     omelette
+    robot
 develop = .
 
 


### PR DESCRIPTION
The test_example.robot file points to bin/robot-server and bin-robot, so it seems logical to install those scripts.