### PR TITLE
Cleanup generated MANIFEST.in, add setup.cfg.

### DIFF
--- a/bobtemplates/plone_addon/MANIFEST.in.bob
+++ b/bobtemplates/plone_addon/MANIFEST.in.bob
@@ -1,3 +1,4 @@
 graft src/{{{ package.namespace }}}
-graft docs/
-include *.cfg *.rst *.in
+graft docs
+include *.rst
+global-exclude *.pyc

--- a/bobtemplates/plone_addon/setup.cfg.bob
+++ b/bobtemplates/plone_addon/setup.cfg.bob
@@ -1,0 +1,7 @@
+[check-manifest]
+ignore =
+    *.cfg
+    .coveragerc
+    .editorconfig
+    .gitattributes
+    bootstrap-buildout.py

--- a/tests.py
+++ b/tests.py
@@ -101,6 +101,7 @@ class PloneTemplateTest(BaseTemplateTest):
                 self.project + '/.coveragerc',
                 self.project + '/.editorconfig',
                 self.project + '/.gitattributes',
+                self.project + '/setup.cfg',
             ]
         )
 
@@ -168,5 +169,6 @@ class PloneTemplateTest(BaseTemplateTest):
                 self.project + '/.coveragerc',
                 self.project + '/.editorconfig',
                 self.project + '/.gitattributes',
+                self.project + '/setup.cfg',
             ]
         )


### PR DESCRIPTION
There is no need to include *cfg files, nothing is done with it.

The MANIFEST.in file is included automatically, so no need to spell it out.

We must globally exclude *.pyc.

In short, the check-manifest command should not complain.  This is a
stand-alone command and an optional helper package for zest.releaser,
called during prerelease.

Also, this fixes an error on Windows, noticed by check-manifest:
ERROR: Trailing slashes are not allowed in MANIFEST.in on Windows: docs/