### PR TITLE
Generated buildout: no plone.app.event 2 on Plone 4.3.

### DIFF
--- a/bobtemplates/hooks.py
+++ b/bobtemplates/hooks.py
@@ -96,15 +96,34 @@ def pre_email(configurator, question):
 def post_plone_version(configurator, question, answer):
     """Find out if it is supposed to be Plone 5.
     """
-    if answer.startswith('5'):
-        configurator.variables['plone.is_plone5'] = True
-    else:
-        configurator.variables['plone.is_plone5'] = False
-    # extract minor version (4.3)
-    # (according to https://plone.org/support/version-support-policy)
-    # this is used for the trove classifier in setup.py of the product
-    configurator.variables['plone.minor_version'] = '.'.join(answer.split('.')[:2])  # noqa
+    _set_plone_version_variables(configurator, answer)
     return answer
+
+
+def _set_plone_version_variables(configurator, version):
+    if 'plone.is_plone5' not in configurator.variables:
+        # Find out if it is supposed to be Plone 5.
+        if version.startswith('5'):
+            configurator.variables['plone.is_plone5'] = True
+        else:
+            configurator.variables['plone.is_plone5'] = False
+    if 'plone.minor_version' not in configurator.variables:
+        # extract minor version (4.3)
+        # (according to https://plone.org/support/version-support-policy)
+        # this is used for the trove classifier in setup.py of the product
+        configurator.variables['plone.minor_version'] = '.'.join(
+            version.split('.')[:2])
+
+
+def post_ask(configurator):
+    """Make sure some variables are set, also in non-interactive mode.
+
+    This is called after all questions have been asked.
+    """
+    version = configurator.variables.get('plone.version')
+    if not version:
+        return
+    _set_plone_version_variables(configurator, version)
 
 
 def post_type(configurator, question, answer):

--- a/bobtemplates/plone_addon/.mrbob.ini
+++ b/bobtemplates/plone_addon/.mrbob.ini
@@ -41,3 +41,4 @@ plone.version.post_ask_question = bobtemplates.hooks:post_plone_version
 [template]
 pre_render = bobtemplates.hooks:prepare_render
 post_render = bobtemplates.hooks:cleanup_package
+post_ask = bobtemplates.hooks:post_ask

--- a/bobtemplates/plone_addon/setup.py.bob
+++ b/bobtemplates/plone_addon/setup.py.bob
@@ -26,7 +26,7 @@ setup(
     classifiers=[
         "Environment :: Web Environment",
         "Framework :: Plone",
-        "Framework :: Plone :: {{{ plone.version }}}",
+        "Framework :: Plone :: {{{ plone.minor_version }}}",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
         "Operating System :: OS Independent",

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/setuphandlers.py.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/setuphandlers.py.bob
@@ -20,8 +20,8 @@ def post_install(context):
     if context.readDataFile('{{{ package.longname }}}_default.txt') is None:
         return
     # Do something during the installation of this package
-
 {{% if plone.is_plone5 %}}
+
 
 def uninstall(context):
     """Uninstall script"""

--- a/nosetests_answers.ini
+++ b/nosetests_answers.ini
@@ -14,5 +14,4 @@ author.github.user = collective
 author.irc = irc.freenode.org#plone
 
 plone.version = 4.3.6
-plone.is_plone5 = False
 python.version = 2.7

--- a/nosetests_answers_nested.ini
+++ b/nosetests_answers_nested.ini
@@ -14,5 +14,4 @@ author.github.user = collective
 author.irc = irc.freenode.org#plone
 
 plone.version = 4.3.6
-plone.is_plone5 = False
 python.version = 2.7

--- a/test_answers.ini
+++ b/test_answers.ini
@@ -13,6 +13,4 @@ author.github.user = collective
 author.irc = irc.freenode.org#plone
 
 plone.version = 4.3.6
-plone.is_plone5 = False
-plone.minor_version = 4.3
 python.version = 2.7

--- a/tests.py
+++ b/tests.py
@@ -89,9 +89,6 @@ class PloneTemplateTest(BaseTemplateTest):
                 self.project + '/src/collective/foo/profiles/default/browserlayer.xml',  # noqa
                 self.project + '/src/collective/foo/profiles/default/collectivefoo_default.txt',  # noqa
                 self.project + '/src/collective/foo/profiles/default/metadata.xml',  # noqa
-                self.project + '/src/collective/foo/profiles/uninstall',  # noqa
-                self.project + '/src/collective/foo/profiles/uninstall/browserlayer.xml',  # noqa
-                self.project + '/src/collective/foo/profiles/uninstall/collectivefoo_uninstall.txt',  # noqa
                 self.project + '/src/collective/foo/setuphandlers.py',
                 self.project + '/src/collective/foo/testing.py',
                 self.project + '/src/collective/foo/tests',
@@ -159,9 +156,6 @@ class PloneTemplateTest(BaseTemplateTest):
                 self.project + '/src/collective/foo/bar/profiles/default/browserlayer.xml',  # noqa
                 self.project + '/src/collective/foo/bar/profiles/default/collectivefoobar_default.txt',  # noqa
                 self.project + '/src/collective/foo/bar/profiles/default/metadata.xml',  # noqa
-                self.project + '/src/collective/foo/bar/profiles/uninstall',  # noqa
-                self.project + '/src/collective/foo/bar/profiles/uninstall/browserlayer.xml',  # noqa
-                self.project + '/src/collective/foo/bar/profiles/uninstall/collectivefoobar_uninstall.txt',  # noqa
                 self.project + '/src/collective/foo/bar/setuphandlers.py',
                 self.project + '/src/collective/foo/bar/testing.py',
                 self.project + '/src/collective/foo/bar/tests',


### PR DESCRIPTION
Pin plone.app.event to 1.2.7 on Plone 4.3.

Should be done nicer, but let's first see if this fixes travis failures.

See problems at pull request #99.