### PR TITLE
Create coverage report in Travis.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+include =
+  bobtemplates/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.egg-info
 *.mo
 *.pyc
+.coverage
 .installed.cfg
 .mr.developer.cfg
 .project
@@ -11,6 +12,7 @@ bin/
 buildout-cache/
 develop-eggs/
 eggs/
+htmlcov/
 include/
 lib/
 local/

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,11 @@ before_script:
 script:
   - bin/check-readme
   - bin/code-analysis
-  - bin/nosetests
   - bin/test
+  - bin/test-plone_addon
 
 after_success:
+  - bin/createcoverage
   - pip install -q coveralls
   - coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - pip install docutils
   - sed -ie "s/^plone.version.*/plone.version = $PLONE_VERSION/g" test_answers.ini
   - sed -ie "s/^package.type.*/package.type = $PACKAGE_TYPE/g" test_answers.ini
-  - if [ "$PACKAGE_TYPE" == "Dexterity" ]; then echo "package.dexterity_type_name = MyDextrityTestType" >> test_answers.ini; fi
+  - if [ "$PACKAGE_TYPE" == "Dexterity" ]; then echo "package.dexterity_type_name = MyDexterityTestType" >> test_answers.ini; fi
   - bin/buildout -c travis.cfg
 
 before_script:

--- a/addon_test.template.sh
+++ b/addon_test.template.sh
@@ -14,7 +14,14 @@ ${buildout:directory}/${:addon_name}/bin/buildout
 
 # run tests on addon
 ${buildout:directory}/${:addon_name}/bin/test --all
+# save the exit code of the test command
+testresult=$?
+
+# run code analysis
 ${buildout:directory}/${:addon_name}/bin/code-analysis
 
 # remove addon
 rm -rf ${buildout:directory}/${:addon_name}/
+
+# return the exit code of the test command
+exit $testresult

--- a/bobtemplates/plone_addon/.travis.yml.bob
+++ b/bobtemplates/plone_addon/.travis.yml.bob
@@ -18,8 +18,8 @@ install:
 script:
   - bin/code-analysis
   - bin/test
-  - bin/createcoverage
 after_success:
+  - bin/createcoverage
   - pip install coveralls
   - coveralls
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,7 +2,9 @@
 parts =
     scripts
     test
+    test-plone_addon
     test-plone_addon-nested
+    alltests
     code-analysis
     releaser
     check-readme
@@ -20,10 +22,17 @@ eggs =
 
 
 [test]
+#  This section is only here to generate the nosetests script a second
+#  time under a different name: 'test'.
+<= scripts
+scripts = nosetests=test
+
+
+[test-plone_addon]
 recipe = collective.recipe.template
 addon_name = test.plone_addon
 input = addon_test.template.sh
-output = ${buildout:directory}/bin/test
+output = ${buildout:directory}/bin/test-plone_addon
 mode = 755
 
 
@@ -32,6 +41,17 @@ recipe = collective.recipe.template
 addon_name = test.nested.plone_addon
 input = addon_test.template.sh
 output = ${buildout:directory}/bin/test-plone_addon-nested
+mode = 755
+
+
+[alltests]
+recipe = collective.recipe.template
+input = inline:
+    #!/bin/sh
+    bin/test
+    bin/test-plone_addon
+    bin/test-plone_addon-nested
+output = ${buildout:directory}/bin/alltests
 mode = 755
 
 

--- a/tests.py
+++ b/tests.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import shutil
 
+from bobtemplates import hooks
 from scripttest import TestFileEnvironment
 
 
@@ -170,3 +171,10 @@ class PloneTemplateTest(BaseTemplateTest):
                 self.project + '/.gitattributes',
             ]
         )
+
+
+class HooksTest(unittest.TestCase):
+
+    def test_to_boolean(self):
+        # Initial simple test to show coverage in hooks.py.
+        self.assertEqual(hooks.to_boolean(None, None, 'y'), True)

--- a/travis.cfg
+++ b/travis.cfg
@@ -1,7 +1,12 @@
 [buildout]
 extends = buildout.cfg
+parts += createcoverage
 
 [code-analysis]
 recipe = plone.recipe.codeanalysis
 pre-commit-hook = False
 return-status-codes = True
+
+[createcoverage]
+recipe = zc.recipe.egg
+eggs = createcoverage


### PR DESCRIPTION
This should solve issue #93, in a slightly different way than my last proposal there.

Generate nosetests script also under the 'test' name.  Then
bin/createcoverage works.

In Travis call the new correct script names:

- The new bin/test is the old bin/nosetests.
- The new bin/test-plone_addon is the old bin/test.

Created bin/alltests script.  This runs bin/test, and the two
test-plone_addon scripts.  We could call that in Travis too.

Added initial simple test to show coverage in hooks.py.