### PR TITLE
change browser layer name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ Changelog
 - Update ``.gitignores`` in repository to exclude ``lib64``, ``pip-selfcheck.json`` and all ``.*`` except necessary.
   Update ``.gitignore.bob`` in templates with these changes too.
   Add ``.gitattributes`` in repository for union-merge CHANGES.rst files.
+- Change the browser layer from the camel case'd package name to
+  ``IBrowserLayer``. This is easier to remember and faster to write. The 
+  interface is prefixed by the package namespace anyways.
   [thet]
 
 - Update robot test framework versions including Selenium to work with recent

--- a/bobtemplates/hooks.py
+++ b/bobtemplates/hooks.py
@@ -179,9 +179,10 @@ def prepare_render(configurator):
     camelcasename = dottedname.replace('.', ' ').title()\
         .replace(' ', '')\
         .replace('_', '')
-    browserlayer = "{0}Layer".format(camelcasename)
 
-    # package.browserlayer = 'CollectiveFooSomethingLayer'
+    browserlayer = "IBrowserLayer"
+
+    # package.browserlayer = 'IBrowserLayer'
     configurator.variables['package.browserlayer'] = browserlayer
 
     # package.longname = 'collectivefoosomething'

--- a/bobtemplates/hooks.py
+++ b/bobtemplates/hooks.py
@@ -176,14 +176,14 @@ def prepare_render(configurator):
         'package.dottedname'
     ].replace('.', '_').upper()
 
+    browserlayer = "BrowserLayer"
+
+    # package.browserlayer = 'BrowserLayer'
+    configurator.variables['package.browserlayer'] = browserlayer
+
     camelcasename = dottedname.replace('.', ' ').title()\
         .replace(' ', '')\
         .replace('_', '')
-
-    browserlayer = "IBrowserLayer"
-
-    # package.browserlayer = 'IBrowserLayer'
-    configurator.variables['package.browserlayer'] = browserlayer
 
     # package.longname = 'collectivefoosomething'
     configurator.variables['package.longname'] = camelcasename.lower()

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/tests/test_setup.py.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/tests/test_setup.py.bob
@@ -23,8 +23,7 @@ class TestSetup(unittest.TestCase):
 
     def test_browserlayer(self):
         """Test that I{{{ package.browserlayer }}} is registered."""
-        from {{{ package.dottedname }}}.interfaces import (
-            I{{{ package.browserlayer }}})
+        from {{{ package.dottedname }}}.interfaces import I{{{ package.browserlayer }}}
         from plone.browserlayer import utils
         self.assertIn(I{{{ package.browserlayer }}}, utils.registered_layers())
 


### PR DESCRIPTION
Change the browser layer from the camel case'd package name to IBrowserLayer. This is easier to remember, more consistent and faster to write. The interface is prefixed by the package namespace anyways.

This is actual my personal habit - I switched from package-individual names to the name ``IThemeLayer`` because of the reasons mentioned above. "Theme" is maybe to opinionated, so I choose "Browser" in this PR, because that's what the interface is - a browser layer.