### PR TITLE
gitignores and gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGES.rst merge=union

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,9 @@
-!src/bobtemplates
+# any of...
+.*
 *.egg-info
 *.mo
 *.pyc
-.coverage
-.installed.cfg
-.mr.developer.cfg
-.project
-.pydevproject
-.settings/
+# dirs
 bin/
 buildout-cache/
 develop-eggs/
@@ -20,3 +16,13 @@ parts/
 src/*
 test.plone_addon/
 var/
+# files
+lib64
+pip-selfcheck.json
+# excludes
+!.coveragerc
+!.editorconfig
+!.gitattributes
+!.gitignore
+!.travis.yml
+!src/bobtemplates

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
+- Update ``.gitignores`` in repository to exclude ``lib64``, ``pip-selfcheck.json`` and all ``.*`` except necessary.
+  Update ``.gitignore.bob`` in templates with these changes too.
+  Add ``.gitattributes`` in repository for union-merge CHANGES.rst files.
+  [thet]
+
 - Update robot test framework versions including Selenium to work with recent
   firefox releases.
   [thet]

--- a/bobtemplates/plone_addon/.gitignore.bob
+++ b/bobtemplates/plone_addon/.gitignore.bob
@@ -1,22 +1,33 @@
+# any of...
+.*
 *.egg-info
+*.log
 *.mo
-*.pyc
-.installed.cfg
-.mr.developer.cfg
-.project
-.pydevproject
-.settings/
+*.py?
+*.swp
+# dirs
 bin/
 buildout-cache/
 develop-eggs/
+eggs/
+htmlcov/
+include/
+lib/
+local/
 parts/
 src/*
-!src/{{{ package.namespace }}}
+test.plone_addon/
 var/
-htmlcov/
-.coverage
-*.log
-output.xml
-*.swp
+# files
+lib64
 log.html
+output.xml
+pip-selfcheck.json
 report.html
+# excludes
+!.coveragerc
+!.editorconfig
+!.gitattributes
+!.gitignore
+!.travis.yml
+!src/{{{ package.namespace }}}


### PR DESCRIPTION
Update ``.gitignores`` in repository to exclude ``lib64``,
``pip-selfcheck.json`` and all ``.*`` except necessary.
Update ``.gitignore.bob`` in templates with these changes too.
Add ``.gitattributes`` in repository for union-merge CHANGES.rst files.