### PR TITLE
Add "(uninstall)" to the uninstall profile title.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
+- Add "(uninstall)" to the uninstall profile title.
+  Otherwise it cannot be distinguished from the install profile in portal_setup.
+  [thet]
+
 - Simplify concatenation of ``.rst`` files for ``setup.py``.
   [thet]
 

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/configure.zcml.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/configure.zcml.bob
@@ -40,7 +40,7 @@
 {{% if plone.is_plone5 %}}
   <genericsetup:registerProfile
       name="uninstall"
-      title="{{{ package.dottedname }}}"
+      title="{{{ package.dottedname }}} (uninstall)"
       directory="profiles/uninstall"
       description="Uninstalls the {{{ package.dottedname }}} add-on."
       provides="Products.GenericSetup.interfaces.EXTENSION"


### PR DESCRIPTION
Otherwise it cannot be distinguished from the install profile in portal_setup.

By the way, why is the uninstall profile only created for Plone 5 and not Plone 4 also?