### PR TITLE
Create uninstall profile also for Plone 4.3.x, since it already depen…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
+- Create uninstall profile also for Plone 4.3.x, since it already depends on ``Products.CMFQuickInstallerTool >= 3.0.9``.
+  [thet]
+
 - Update Plone versions to 4.3.9 and 5.0.4.
   [thet]
 

--- a/bobtemplates/hooks.py
+++ b/bobtemplates/hooks.py
@@ -286,11 +286,6 @@ def cleanup_package(configurator):
             "{0}/tests/robot/test_.robot",
         ])
 
-    if not configurator.variables['plone.is_plone5']:
-        to_delete.extend([
-            "{0}/profiles/uninstall",
-        ])
-
     # remove parts
     for path in to_delete:
         path = path.format(base_path)

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/configure.zcml.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/configure.zcml.bob
@@ -30,7 +30,6 @@
       post_handler=".setuphandlers.post_install"
       />
 
-{{% if plone.is_plone5 %}}
   <genericsetup:registerProfile
       name="uninstall"
       title="{{{ package.dottedname }}} (uninstall)"
@@ -44,5 +43,4 @@
       factory=".setuphandlers.HiddenProfiles"
       name="{{{ package.dottedname }}}-hiddenprofiles" />
 
-{{% endif %}}
 </configure>

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/setuphandlers.py.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/setuphandlers.py.bob
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-{{% if plone.is_plone5 %}}
 from Products.CMFPlone.interfaces import INonInstallable
 from zope.interface import implementer
 
@@ -12,16 +11,13 @@ class HiddenProfiles(object):
         return [
             '{{{ package.dottedname }}}:uninstall',
         ]
-{{% endif %}}
 
 
 def post_install(context):
     """Post install script"""
     # Do something at the end of the installation of this package.
-{{% if plone.is_plone5 %}}
 
 
 def uninstall(context):
     """Uninstall script"""
     # Do something at the end of the uninstallation of this package.
-{{% endif %}}

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/tests/test_setup.py.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/tests/test_setup.py.bob
@@ -42,11 +42,9 @@ class TestUninstall(unittest.TestCase):
         """Test if {{{ package.dottedname }}} is cleanly uninstalled."""
         self.assertFalse(self.installer.isProductInstalled(
             '{{{ package.dottedname }}}'))
-{{% if plone.is_plone5 %}}
 
     def test_browserlayer_removed(self):
         """Test that I{{{ package.browserlayer }}} is removed."""
         from {{{ package.dottedname }}}.interfaces import I{{{ package.browserlayer }}}
         from plone.browserlayer import utils
         self.assertNotIn(I{{{ package.browserlayer }}}, utils.registered_layers())
-{{% endif %}}

--- a/tests.py
+++ b/tests.py
@@ -89,6 +89,8 @@ class PloneTemplateTest(BaseTemplateTest):
                 self.project + '/src/collective/foo/profiles/default',
                 self.project + '/src/collective/foo/profiles/default/browserlayer.xml',  # noqa
                 self.project + '/src/collective/foo/profiles/default/metadata.xml',  # noqa
+                self.project + '/src/collective/foo/profiles/uninstall',
+                self.project + '/src/collective/foo/profiles/uninstall/browserlayer.xml',  # noqa
                 self.project + '/src/collective/foo/setuphandlers.py',
                 self.project + '/src/collective/foo/testing.py',
                 self.project + '/src/collective/foo/tests',
@@ -156,6 +158,8 @@ class PloneTemplateTest(BaseTemplateTest):
                 self.project + '/src/collective/foo/bar/profiles/default',
                 self.project + '/src/collective/foo/bar/profiles/default/browserlayer.xml',  # noqa
                 self.project + '/src/collective/foo/bar/profiles/default/metadata.xml',  # noqa
+                self.project + '/src/collective/foo/bar/profiles/uninstall',
+                self.project + '/src/collective/foo/bar/profiles/uninstall/browserlayer.xml',  # noqa
                 self.project + '/src/collective/foo/bar/setuphandlers.py',
                 self.project + '/src/collective/foo/bar/testing.py',
                 self.project + '/src/collective/foo/bar/tests',


### PR DESCRIPTION
…ds on Products.CMFQuickInstallerTool >= 3.0.9.

@pbauer may you review, as you added the plone5 condition in https://github.com/plone/bobtemplates.plone/commit/7047805779115fa726e3ad70091e845f2d22e00e