### PR TITLE
Complete the theme.xml GenericSetup registry file with an a xmlheader…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
+- Complete the ``theme.xml`` GenericSetup registry file with an a xmlheader and a ``themes`` tag.
+  [thet]
+
 - Add "(uninstall)" to the uninstall profile title.
   Otherwise it cannot be distinguished from the install profile in portal_setup.
   [thet]

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/default/theme.xml.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/default/theme.xml.bob
@@ -1,4 +1,7 @@
-<theme>
-  <name>{{{ package.dottedname }}}</name>
-  <enabled>true</enabled>
-</theme>
+<?xml version="1.0"?>
+<themes>
+  <theme>
+    <name>{{{ package.dottedname }}}</name>
+    <enabled>true</enabled>
+  </theme>
+</themes>

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/uninstall/theme.xml.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/uninstall/theme.xml.bob
@@ -1,4 +1,7 @@
-<theme>
-  <name>{{{ package.dottedname }}}</name>
-  <enabled>false</enabled>
-</theme>
+<?xml version="1.0"?>
+<themes>
+  <theme>
+    <name>{{{ package.dottedname }}}</name>
+    <enabled>false</enabled>
+  </theme>
+</themes>


### PR DESCRIPTION
… and a themes tag.

The ``theme.xml`` fell somehow out of the convention we follow for other GS xml files. No xml header tag and how to add more than one theme?

We should follow best practices also here, if this is best practice.

However, disabling a theme with ``<enabled>false</enabled>`` (as in the uninstall profile) doesn't realy work - we'd had to enable another one instead. Enabling barceloneta seems also not to work. However, these are plone.app.theming issues.