### PR TITLE
Add encoding to all GS xml declarations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
+- Declare the xml encoding for all GenericSetup profile files.
+  Otherwise the parser has to autodetect it.
+  Also add an xml version and encoding declaration to ``theme.xml``.
+  [thet]
+
 - Add "(uninstall)" to the uninstall profile title.
   Otherwise it cannot be distinguished from the install profile in portal_setup.
   [thet]

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/default/browserlayer.xml.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/default/browserlayer.xml.bob
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <layers>
   <layer
       name="{{{ package.dottedname }}}"

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/default/metadata.xml.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/default/metadata.xml.bob
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <metadata>
   <version>1000</version>
   <dependencies>

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/default/theme.xml.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/default/theme.xml.bob
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <theme>
   <name>{{{ package.dottedname }}}</name>
   <enabled>true</enabled>

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/default/types.xml.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/default/types.xml.bob
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <object name="portal_types" meta_type="Plone Types Tool">
   <object name="{{{ package.dexterity_type_name }}}" meta_type="Dexterity FTI"/>
 </object>

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/default/types/+package.dexterity_type_name+.xml.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/default/types/+package.dexterity_type_name+.xml.bob
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <object name="{{{ package.dexterity_type_name }}}" meta_type="Dexterity FTI" i18n:domain="{{{ package.dottedname }}}"
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
   <property name="title" i18n:translate="">{{{ package.dexterity_type_name }}}</property>

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/uninstall/browserlayer.xml.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/uninstall/browserlayer.xml.bob
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <layers>
   <layer
       name="{{{ package.dottedname }}}"

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/uninstall/theme.xml.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/uninstall/theme.xml.bob
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <theme>
   <name>{{{ package.dottedname }}}</name>
   <enabled>false</enabled>


### PR DESCRIPTION
Declare the xml encoding for all GenericSetup profile files.
Otherwise the parser has to autodetect it.
Also add an xml version and encoding declaration to ``theme.xml``.

/cc @jensens thinking this further, shouldn't ZCML files also get this xml declaration heading ``<?xml version="1.0" encoding="UTF-8"?>``?