### PR TITLE
Removed `.*` from the `.gitignore` file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-# any of...
-.*
 *.egg-info
 *.mo
 *.pyc

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
+- Removed ``.*`` from the ``.gitignore`` file.  This would ignore the
+  ``.gitkeep`` files, which would mean some directories are not added
+  when you do ``git add`` after generating a new project.  [maurits]
+
 - Note about disabled ``z3c.autoinclude`` in test layer setup.
   [thet]
 

--- a/bobtemplates/plone_addon/.gitignore.bob
+++ b/bobtemplates/plone_addon/.gitignore.bob
@@ -1,5 +1,3 @@
-# any of...
-.*
 *.egg-info
 *.log
 *.mo


### PR DESCRIPTION
This would ignore the `.gitkeep` files, which would mean some directories are not added when you do `git add` after generating a new project.

I had to fix this afterwards in a package I generated, where Zope failed to start up when a colleague tried it, because the `static` and `overrides` directories had not been added:
https://github.com/zestsoftware/collective.calltoaction/commit/1d1353a619354e6729e5ba30303146a427085481