### PR TITLE
plone testing 5.0.0 dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,10 @@ Changelog
 - Enabled robot part in generated package.
   [maurits]
 
+- Add depedency on plone.testing 5.0.0. Despite the major version number,
+  this change does not contain breaking changes.
+  [do3cc]
+
 - Fix #84 Make travis cache the egg directory of the generated package.
   [jensens]
 

--- a/bobtemplates/plone_addon/buildout.cfg.bob
+++ b/bobtemplates/plone_addon/buildout.cfg.bob
@@ -78,3 +78,4 @@ selenium = 2.48.0
 {{% if not plone.is_plone5 %}}
 plone.app.locales = 4.3.9
 {{% endif %}}
+plone.testing = 5.0.0

--- a/bobtemplates/plone_addon/setup.py.bob
+++ b/bobtemplates/plone_addon/setup.py.bob
@@ -52,6 +52,10 @@ setup(
     extras_require={
         'test': [
             'plone.app.testing',
+            # Plone KGS does not use this version, because it would break
+            # Remove if your package shall be part of coredev.
+            # plone_coredev tests as of 2016-04-01.
+            'plone.testing>=5.0.0',
             'plone.app.contenttypes',
             'plone.app.robotframework[debug]',
         ],


### PR DESCRIPTION
plone.testing 5.0.0 is backward compatible and helps users to avoid some common errors when writing tests.