### PR TITLE
Set year in LICENSE.rst automatically.

### DIFF
--- a/bobtemplates/hooks.py
+++ b/bobtemplates/hooks.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Render bobtemplates.plone hooks.
 """
+from datetime import date
 from mrbob.bobexceptions import SkipQuestion
 from mrbob.bobexceptions import ValidationError
 from mrbob.hooks import validate_choices
@@ -120,6 +121,7 @@ def post_ask(configurator):
 
     This is called after all questions have been asked.
     """
+    configurator.variables['year'] = date.today().year
     version = configurator.variables.get('plone.version')
     if not version:
         return

--- a/bobtemplates/plone_addon/docs/LICENSE.rst.bob
+++ b/bobtemplates/plone_addon/docs/LICENSE.rst.bob
@@ -1,4 +1,4 @@
-{{{ package.dottedname }}} Copyright 2015, {{{ author.name }}}
+{{{ package.dottedname }}} Copyright {{{ year }}}, {{{ author.name }}}
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License version 2

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/theme/index.html
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/theme/index.html
@@ -159,7 +159,7 @@
     </div>
 
     <footer>
-      <p>&copy; Company 2015</p>
+      <p>&copy; Company 2016</p>
     </footer>
 
   </div><!-- /.container -->


### PR DESCRIPTION
It was hardcoded to 2015 until now.

Also updated the hardcoded year in the the `index.html` to the also hardcoded 2016. We could make this a `index.html.bob` and fill in the calculated year, but the user needs to update this file anyway, at the least to replace `Company` with a real name.