### PR TITLE
Bump setup tools version to 21.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 
 - Ordered sections of generated FTI xml into semantical block and added comments for each block.
   [jensens]
+  
+- Bump setuptools version to 21.0.0 in buildout.cfg.bob
+  [staeff]
 
 
 1.0.3 (2016-04-13)

--- a/bobtemplates/plone_addon/buildout.cfg.bob
+++ b/bobtemplates/plone_addon/buildout.cfg.bob
@@ -65,7 +65,7 @@ eggs = i18ndude
 # Don't use a released version of {{{ package.dottedname }}}
 {{{ package.dottedname }}} =
 
-setuptools = 20.7.0
+setuptools = 21.0.0
 zc.buildout = 2.5.1
 zc.recipe.egg = 2.0.3
 flake8 = 2.5.4


### PR DESCRIPTION
I had to bump the version of setuptools to succesfully run buildout on a package with *5.0-latest* version