### PR TITLE
ignore buildout generated dot.cfg files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
+- Git ignore ``.installed.cfg`` and ``mr.developer.cfg`` by default.
+  [jensens]
+
 - Ordered sections of generated FTI xml into semantical block and added comments for each block.
   [jensens]
   

--- a/bobtemplates/plone_addon/.gitignore.bob
+++ b/bobtemplates/plone_addon/.gitignore.bob
@@ -18,6 +18,8 @@ src/*
 test.plone_addon/
 var/
 # files
+.installed.cfg
+.mr.developer.cfg
 lib64
 log.html
 output.xml


### PR DESCRIPTION
No reason to add ``.installed.cfg`` and ``.mr.developer.cfg`` to git by default, so ignore them.