### PR TITLE
add isort configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Changelog
 - Git ignore ``.installed.cfg`` and ``mr.developer.cfg`` by default.
   [jensens]
 
+- ``isort`` style checks are enabled, but no config was set. i
+  Added config according to http://docs.plone.org/develop/styleguide/python.html#grouping-and-sorting
+  [jensens]
+
 - Ordered sections of generated FTI xml into semantical block and added comments for each block.
   [jensens]
   

--- a/bobtemplates/plone_addon/setup.cfg.bob
+++ b/bobtemplates/plone_addon/setup.cfg.bob
@@ -5,3 +5,10 @@ ignore =
     .editorconfig
     .gitattributes
     bootstrap-buildout.py
+
+[isort]
+force_alphabetical_sort = True
+force_single_line = True
+lines_after_imports = 2
+line_length = 200
+not_skip = __init__.py

--- a/bobtemplates/plone_addon/setup.cfg.bob
+++ b/bobtemplates/plone_addon/setup.cfg.bob
@@ -7,8 +7,11 @@ ignore =
     bootstrap-buildout.py
 
 [isort]
+# for details see
+# http://docs.plone.org/develop/styleguide/python.html#grouping-and-sorting
 force_alphabetical_sort = True
 force_single_line = True
 lines_after_imports = 2
 line_length = 200
 not_skip = __init__.py
+


### PR DESCRIPTION
Currently isort style checks are enabled, but no config was set. Added config according to http://docs.plone.org/develop/styleguide/python.html#grouping-and-sorting