### PR TITLE
Version pin on coverage and createcoverage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
+- Pin versions of coverage/createcoverage
+  [staeff]
+
 - Default to Plone 5.0.4.
   [jensens]
 

--- a/bobtemplates/plone_addon/.travis.yml.bob
+++ b/bobtemplates/plone_addon/.travis.yml.bob
@@ -20,7 +20,7 @@ script:
   - bin/test
 after_success:
   - bin/createcoverage
-  - pip install coveralls
+  - pip install coverage==3.7 coveralls
   - coveralls
 
 notifications:

--- a/bobtemplates/plone_addon/travis.cfg.bob
+++ b/bobtemplates/plone_addon/travis.cfg.bob
@@ -15,3 +15,7 @@ return-status-codes = True
 [createcoverage]
 recipe = zc.recipe.egg
 eggs = createcoverage
+
+[versions]
+coverage = 3.7
+createcoverage = 1.4.1


### PR DESCRIPTION
Without this pin travis can not complete the buildout. It fails with this error message:
"Error: The requirement ('coverage>=3.7') is not allowed by your [versions] constraint (3.5.2)"
The solution for the problem was taken from here
https://community.plone.org/t/createcoverage-coveralls-io-version-conflicts/1188