### PR TITLE
Explicitly load ZCML for locale overloading

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
+- Add the generated package explicitly to the buildouts instance zcml section to make sure it's loaded first.
+  That ensures, that core locales can be overloaded by the package.
+  [thet]
+
 - Pin versions of coverage/createcoverage
   [staeff]
 

--- a/bobtemplates/plone_addon/buildout.cfg.bob
+++ b/bobtemplates/plone_addon/buildout.cfg.bob
@@ -21,6 +21,10 @@ eggs =
     Pillow
     {{{ package.dottedname }}} [test]
 
+# To be able to overload core locales, our package zcml needs to be loaded first.
+zcml =
+    {{{ package.dottedname }}}
+
 
 [code-analysis]
 recipe = plone.recipe.codeanalysis[recommended]


### PR DESCRIPTION
Add the generated package explicitly to the buildouts instance zcml section to make sure it's loaded first.
That ensures that core locales can be overloaded by the package.

/cc @mauritsvanrees 