### PR TITLE
Allow ttw-overrrides of resources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use plone:static instead of browser:resourceDirectory to allow ttw-overrrides.
+  [pbauer]
 
 
 1.0.4 (2016-07-23)

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/browser/configure.zcml.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/browser/configure.zcml.bob
@@ -12,8 +12,9 @@
       />
 
   <!-- Publish static files -->
-  <browser:resourceDirectory
+  <plone:static
       name="{{{ package.dottedname }}}"
+      type="plone"
       directory="static"
       />
 


### PR DESCRIPTION
Use plone:static instead of browser:resourceDirectory to allow ttw-overrrides. Fixes #159