### PR TITLE
Change default values for code analysis' return-status-codes directive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.0.6 (unreleased)
 ------------------
 
+- Change default values for code analysis' ``return-status-codes`` directive:
+  it is now ``False`` on development and ``True`` on CI.
+  [hvelarde]
+
 - Add requirements.txt and update README.txt to use it
   [MrTango]
 

--- a/bobtemplates/plone_addon/.travis.yml.bob
+++ b/bobtemplates/plone_addon/.travis.yml.bob
@@ -10,8 +10,8 @@ matrix:
   fast_finish: true
 install:
   - python bootstrap-buildout.py
-  - bin/buildout -N buildout:download-cache=downloads annotate
-  - bin/buildout -N buildout:download-cache=downloads
+  - bin/buildout -N buildout:download-cache=downloads code-analysis:return-status-codes=True annotate
+  - bin/buildout -N buildout:download-cache=downloads code-analysis:return-status-codes=True
 before_script:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start

--- a/bobtemplates/plone_addon/buildout.cfg.bob
+++ b/bobtemplates/plone_addon/buildout.cfg.bob
@@ -35,7 +35,7 @@ recipe = plone.recipe.codeanalysis[recommended]
 directory = ${buildout:directory}/src/{{{ package.namespace }}}
 flake8-exclude = bootstrap.py,bootstrap-buildout.py,docs,*.egg.,omelette
 flake8-max-complexity = 15
-return-status-codes = True
+return-status-codes = False
 
 
 [createcoverage]


### PR DESCRIPTION
It is now False on development and True on CI.

closes #184 