### PR TITLE
Sneridagh clarification backendxml

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Changelog
   [MrTango]
 
 - Make cleanup hook windows friendly.
-  [gforcadgia]
+  [gforcada]
 
 - Move LICENSE.rst out of docs folder into top level.
   [gforcada]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,12 +11,17 @@ Changelog
   [MrTango]
 
 - Make cleanup hook windows friendly.
-  [gforcada]
+  [gforcadgia]
 
 - Move LICENSE.rst out of docs folder into top level.
   [gforcada]
 
 - Get rid of the last two code violations on generated package
+  [sneridagh]
+
+- Comment the toolbar rule by default in backend.xml and add a comment on how
+  to add it properly if backend.xml is used. Declaring the toolbar rule twice
+  causes the toolbar JS stop working properly
   [sneridagh]
 
 1.0.5 (2016-10-16)

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/theme/backend.xml
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/theme/backend.xml
@@ -26,7 +26,7 @@
 
   <!-- Toolbar -->
   <!-- Commented out by default, if you are using backend.xml you should only
-  add the toolbar rules once (in main rules.xml) or here. Using it twice cause
+  add the toolbar rules once in main rules.xml or here. Using it twice cause
   that the toolbar pattern stop working properly. Uncomment if you already have
   commented the ones in rules.xml -->
   <!--

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/theme/backend.xml
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/theme/backend.xml
@@ -25,8 +25,14 @@
     -->
 
   <!-- Toolbar -->
+  <!-- Commented out by default, if you are using backend.xml you should only
+  add the toolbar rules once (in main rules.xml) or here. Using it twice cause
+  that the toolbar pattern stop working properly. Uncomment if you already have
+  commented the ones in rules.xml -->
+  <!--
   <before css:theme-children="body" css:content-children="#edit-bar" css:if-not-content=".ajax_load" css:if-content=".userrole-authenticated" />
   <replace css:theme="#anonymous-actions" css:content-children="#portal-personaltools-wrapper" css:if-not-content=".ajax_load" css:if-content=".userrole-anonymous" />
+  -->
 
   <!-- We don't want overlays -->
   <drop attributes="class" css:content="#edit-bar a.pat-plone-modal" />


### PR DESCRIPTION
Comment the toolbar rule by default in backend.xml and add a comment on how to add it properly if backend.xml is used. Declaring the toolbar rule twice causes the toolbar JS stop working.