### PR TITLE
Pin flake8 to latest (3.3.0) to allow use of latest pycodestyle (2.3.1).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0.6 (unreleased)
 ------------------
 
+- Pin flake8 to latest (3.3.0) to allow use of latest pycodestyle (2.3.1)
+  [fulv]
+  
 - Imrove wording
   [svx]
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -87,4 +87,5 @@ setuptools =
 zc.buildout =
 flake8 = 3.3.0
 flake8-coding = 1.3.0
+pycodestyle = 2.3.1
 zc.recipe.egg = 2.0.3

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -85,6 +85,6 @@ mode = 755
 [versions]
 setuptools =
 zc.buildout =
-flake8 = 3.0.4
+flake8 = 3.3.0
 flake8-coding = 1.3.0
 zc.recipe.egg = 2.0.3


### PR DESCRIPTION
Fixes #194