### PR TITLE
Fixed i18n attributes for View/Edit actions in dexterity type xml.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 2.0 (unreleased)
 ------------------
 
+- Fixed i18n attributes for View/Edit actions in dexterity type xml.  [maurits]
+
 - Seperate theme template from addon template, we now have plone_addon and plone_theme_package
   [MrTango]
 

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/default/types/+package.dexterity_type_name+.xml.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/profiles/default/types/+package.dexterity_type_name+.xml.bob
@@ -70,7 +70,7 @@
       category="object"
       condition_expr=""
       description=""
-      i18n:attributes="title description"
+      i18n:attributes="title; description"
       title="View"
       url_expr="string:${object_url}"
       visible="True">
@@ -81,7 +81,7 @@
       category="object"
       condition_expr=""
       description=""
-      i18n:attributes="title description"
+      i18n:attributes="title; description"
       title="Edit"
       url_expr="string:${object_url}/edit"
       visible="True">

--- a/bobtemplates/plone_theme_package/src/+package.namespace+/+package.name+/profiles/default/types/+package.dexterity_type_name+.xml.bob
+++ b/bobtemplates/plone_theme_package/src/+package.namespace+/+package.name+/profiles/default/types/+package.dexterity_type_name+.xml.bob
@@ -70,7 +70,7 @@
       category="object"
       condition_expr=""
       description=""
-      i18n:attributes="title description"
+      i18n:attributes="title; description"
       title="View"
       url_expr="string:${object_url}"
       visible="True">
@@ -81,7 +81,7 @@
       category="object"
       condition_expr=""
       description=""
-      i18n:attributes="title description"
+      i18n:attributes="title; description"
       title="Edit"
       url_expr="string:${object_url}/edit"
       visible="True">


### PR DESCRIPTION
I got a warning when running the update script:

```
$ ./update.sh
Warning: msgid 'description' in ../profiles/default/types/Graph.xml already exists
with a different default (bad: Edit, should be: View)
The references for the existent value are:
../profiles/default/types/Graph.xml
```

This pointed to the real problem. We were using
`i18n:attributes="title description"` which means:
translate the `title` attribute and give it message id `description`.
With the new code, we say: translate both the `title` and `description` attributes,
without giving an explicit message id.