### PR TITLE
Set the zope_i18n_compile_mo_files environment variable.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 2.0 (unreleased)
 ------------------
 
+- Set the zope_i18n_compile_mo_files environment variable.  [maurits]
+
 - Fixed i18n attributes for View/Edit actions in dexterity type xml.  [maurits]
 
 - Seperate theme template from addon template, we now have plone_addon and plone_theme_package

--- a/bobtemplates/plone_addon/buildout.cfg.bob
+++ b/bobtemplates/plone_addon/buildout.cfg.bob
@@ -20,6 +20,8 @@ develop = .
 recipe = plone.recipe.zope2instance
 user = admin:admin
 http-address = 8080
+environment-vars =
+    zope_i18n_compile_mo_files true
 eggs =
     Plone
     Pillow

--- a/bobtemplates/plone_fattheme_buildout/buildout.cfg.bob
+++ b/bobtemplates/plone_fattheme_buildout/buildout.cfg.bob
@@ -11,6 +11,8 @@ parts =
 recipe = plone.recipe.zope2instance
 user = admin:admin
 http-address = 8080
+environment-vars =
+    zope_i18n_compile_mo_files true
 eggs =
     Plone
     Pillow


### PR DESCRIPTION
Otherwise no `.mo` files are created when Plone starts up and you do not get any translations.