### PR TITLE
Add missing parameter to make subtemplates work

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 3.0.0a3 (unreleased)
 --------------------
 
+- Fix missing parameter in _get_package_root_folder call
+  [erral]
+
 - Fix #222 default travis setup is broken.
   [jensens, pbauer]
 

--- a/bobtemplates/plone/base.py
+++ b/bobtemplates/plone/base.py
@@ -128,7 +128,7 @@ def check_root_folder(configurator, question):
     Should be called in first question pre hook.
 
     """
-    root_folder = _get_package_root_folder()
+    root_folder = _get_package_root_folder(configurator)
     if not root_folder:
         raise ValidationError(
             '\n\nNo setup.py found in path!\n'


### PR DESCRIPTION
`configurator` parameter is missing from the call and breaks when you try to call a subtemplate