### PR TITLE
Use uppercased content-type names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 3.0.0a3 (unreleased)
 --------------------
 
+- Create uppercased content-types.
+  [erral]
+
 - Fix #222 default travis setup is broken.
   [jensens, pbauer]
 

--- a/bobtemplates/plone/content_type.py
+++ b/bobtemplates/plone/content_type.py
@@ -83,7 +83,7 @@ def _update_types_xml(configurator):
         parser = etree.XMLParser(remove_blank_text=True)
         tree = etree.parse(xml_file, parser)
         types = tree.xpath("/object[@name='portal_types']")[0]
-        type_name = configurator.variables['dexterity_type_name_normalized']
+        type_name = configurator.variables['dexterity_type_name_klass']
         if len(types.xpath("./object[@name='{name}']".format(name=type_name))):
             print('{name} already in types.xml, skip adding!'.format(name=type_name))  # NOQA: E501
             return

--- a/bobtemplates/plone/content_type/profiles/default/types/+dexterity_type_name_klass+.xml.bob
+++ b/bobtemplates/plone/content_type/profiles/default/types/+dexterity_type_name_klass+.xml.bob
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    name="{{{ dexterity_type_name_normalized }}}"
+    name="{{{ dexterity_type_name_klass }}}"
     meta_type="Dexterity FTI"
     i18n:domain="{{{ package.dottedname }}}">
 
@@ -13,7 +13,7 @@
       name="description">{{{ dexterity_type_desc }}}</property>
 
   <property name="allow_discussion">False</property>
-  <property name="factory">{{{ dexterity_type_name_normalized }}}</property>
+  <property name="factory">{{{ dexterity_type_name_klass }}}</property>
 {{% if plone.is_plone5 %}}
   <property name="icon_expr"></property>
 {{% else %}}
@@ -68,7 +68,7 @@
   </property>
 
   <!-- View information -->
-  <property name="add_view_expr">string:${folder_url}/++add++{{{ dexterity_type_name_normalized }}}</property>
+  <property name="add_view_expr">string:${folder_url}/++add++{{{ dexterity_type_name_klass }}}</property>
   <property name="default_view">view</property>
   <property name="default_view_fallback">False</property>
   <property name="immediate_view">view</property>

--- a/bobtemplates/plone/content_type/tests/robot/test_+dexterity_type_name_normalized+.robot.bob
+++ b/bobtemplates/plone/content_type/tests/robot/test_+dexterity_type_name_normalized+.robot.bob
@@ -56,10 +56,10 @@ a logged-in site administrator
   Enable autologin as  Site Administrator
 
 an add {{{ dexterity_type_name_normalized }}} form
-  Go To  ${PLONE_URL}/++add++{{{ dexterity_type_name_normalized }}}
+  Go To  ${PLONE_URL}/++add++{{{ dexterity_type_name_klass }}}
 
 a {{{ dexterity_type_name_normalized }}} 'My {{{ dexterity_type_name }}}'
-  Create content  type={{{ dexterity_type_name_normalized }}}  id=my-{{{ dexterity_type_name_normalized }}}  title=My {{{ dexterity_type_name }}}
+  Create content  type={{{ dexterity_type_name_klass }}}  id=my-{{{ dexterity_type_name_normalized }}}  title=My {{{ dexterity_type_name }}}
 
 
 # --- WHEN -------------------------------------------------------------------

--- a/bobtemplates/plone/content_type/tests/test_+dexterity_type_name_normalized+.py.bob
+++ b/bobtemplates/plone/content_type/tests/test_+dexterity_type_name_normalized+.py.bob
@@ -28,7 +28,7 @@ class {{{ dexterity_type_name_klass }}}IntegrationTest(unittest.TestCase):
         fti = queryUtility(IDexterityFTI, name='{{{ dexterity_type_name_klass }}}')
         schema = fti.lookupSchema()
 {{% if dexterity_type_supermodel %}}
-        schema_name = "plone_0_{{{ dexterity_type_name_normalized }}}"
+        schema_name = "plone_0_{{{ dexterity_type_name_klass }}}"
         self.assertEqual(schema_name, schema.getName())
 {{% else %}}
         self.assertEqual(I{{{ dexterity_type_name_klass }}}, schema)

--- a/bobtemplates/plone/content_type/tests/test_+dexterity_type_name_normalized+.py.bob
+++ b/bobtemplates/plone/content_type/tests/test_+dexterity_type_name_normalized+.py.bob
@@ -25,7 +25,7 @@ class {{{ dexterity_type_name_klass }}}IntegrationTest(unittest.TestCase):
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
 
     def test_schema(self):
-        fti = queryUtility(IDexterityFTI, name='{{{ dexterity_type_name_normalized }}}')
+        fti = queryUtility(IDexterityFTI, name='{{{ dexterity_type_name_klass }}}')
         schema = fti.lookupSchema()
 {{% if dexterity_type_supermodel %}}
         schema_name = "plone_0_{{{ dexterity_type_name_normalized }}}"
@@ -35,11 +35,11 @@ class {{{ dexterity_type_name_klass }}}IntegrationTest(unittest.TestCase):
 {{% endif %}}
 
     def test_fti(self):
-        fti = queryUtility(IDexterityFTI, name='{{{ dexterity_type_name_normalized }}}')
+        fti = queryUtility(IDexterityFTI, name='{{{ dexterity_type_name_klass }}}')
         self.assertTrue(fti)
 
     def test_factory(self):
-        fti = queryUtility(IDexterityFTI, name='{{{ dexterity_type_name_normalized }}}')
+        fti = queryUtility(IDexterityFTI, name='{{{ dexterity_type_name_klass }}}')
         factory = fti.factory
         obj = createObject(factory)
 {{% if dexterity_type_create_class %}}
@@ -52,7 +52,7 @@ class {{{ dexterity_type_name_klass }}}IntegrationTest(unittest.TestCase):
         setRoles(self.portal, TEST_USER_ID, ['Contributor'])
         obj = api.content.create(
             container=self.portal,
-            type='{{{ dexterity_type_name_normalized }}}',
+            type='{{{ dexterity_type_name_klass }}}',
             id='{{{ dexterity_type_name_normalized }}}',
         )
 {{% if dexterity_type_create_class %}}


### PR DESCRIPTION
I think that to be consistent with the basic content-types provided by Plone, the ones created using bobtemplates.plone should also be uppercased (`Video` instead of `video`).

What do you think?

