### PR TITLE
Fix coveralls by converting .coverage from pickle to json

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.0.0a4 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Fix coveralls for packages created with addon and theme_package by converting the pickle output of createcoverage in .coverage to json.
+  [pbauer]
 
 
 3.0.0a3 (2017-10-30)

--- a/bobtemplates/plone/addon/.travis.yml.bob
+++ b/bobtemplates/plone/addon/.travis.yml.bob
@@ -23,6 +23,8 @@ script:
   - bin/test
 after_success:
   - bin/createcoverage
+  - bin/pip install coverage
+  - bin/python -m coverage.pickle2json
   - pip install coveralls
   - coveralls
 notifications:

--- a/bobtemplates/plone/theme_package/.travis.yml.bob
+++ b/bobtemplates/plone/theme_package/.travis.yml.bob
@@ -23,6 +23,8 @@ script:
   - bin/test
 after_success:
   - bin/createcoverage
+  - bin/pip install coverage
+  - bin/python -m coverage.pickle2json
   - pip install coveralls
   - coveralls
 notifications:


### PR DESCRIPTION
Not sure if this is the current best practice. See https://community.plone.org/t/createcoverage-coveralls-io-version-conflicts/1188