### PR TITLE
Update setuptools and zc.buildout versions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ Changelog
 - fix linting problems and error in theme_package tests
   [MrTango]
 
+- Update setuptools and zc.buildout versions.
+  [tmassman]
+
 
 3.0.0a3 (2017-10-30)
 --------------------

--- a/bobtemplates/plone/addon/buildout.cfg.bob
+++ b/bobtemplates/plone/addon/buildout.cfg.bob
@@ -80,7 +80,7 @@ plone.app.dexterity = 2.1.1
 {{% endif %}}
 
 # development dependencies (tools and pre commit hook)
-setuptools = 33.1.1
+setuptools =
 zc.buildout =
 PyYAML = 3.12
 argh = 0.26.2

--- a/bobtemplates/plone/addon/requirements.txt
+++ b/bobtemplates/plone/addon/requirements.txt
@@ -1,2 +1,2 @@
-zc.buildout==2.9.5
-setuptools==33.1.1
+setuptools==38.2.4
+zc.buildout==2.10.0

--- a/bobtemplates/plone/buildout/requirements.txt
+++ b/bobtemplates/plone/buildout/requirements.txt
@@ -1,2 +1,2 @@
-setuptools==33.1.1
-zc.buildout==2.8.0
+setuptools==38.2.4
+zc.buildout==2.10.0

--- a/bobtemplates/plone/theme_package/buildout.cfg.bob
+++ b/bobtemplates/plone/theme_package/buildout.cfg.bob
@@ -84,8 +84,8 @@ update-command = cd ${buildout:directory}; grunt compile
 {{{ package.dottedname }}} =
 
 # development dependencies (tools and pre commit hook)
-setuptools = 33.1.1
-zc.buildout = 2.8.0
+setuptools =
+zc.buildout =
 PyYAML = 3.12
 argh = 0.26.2
 args = 0.1.0

--- a/bobtemplates/plone/theme_package/requirements.txt
+++ b/bobtemplates/plone/theme_package/requirements.txt
@@ -1,2 +1,2 @@
-setuptools == 33.1.1
-zc.buildout == 2.8.0
+setuptools==38.2.4
+zc.buildout==2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-setuptools==33.1.1
-zc.buildout==2.8.0
+setuptools==38.2.4
+zc.buildout==2.10.0
 Sphinx==1.6.3


### PR DESCRIPTION
Use newest versions for requirements.txt files and unpin versions in buildout configurations.