### PR TITLE
Improve documentation template, generate valid reST

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Changelog
 - Update setuptools and zc.buildout versions.
   [tmassman]
 
+- Imporve docs template for valid reST generation
+  [svx]
 
 3.0.0a3 (2017-10-30)
 --------------------

--- a/bobtemplates/plone/addon/docs/index.rst.bob
+++ b/bobtemplates/plone/addon/docs/index.rst.bob
@@ -1,5 +1,5 @@
-====================
+{{% for i in package.dottedname %}}={{% endfor %}}
 {{{ package.dottedname }}}
-====================
+{{% for i in package.dottedname %}}={{% endfor %}}
 
 User documentation

--- a/bobtemplates/plone/theme_package/README.rst.bob
+++ b/bobtemplates/plone/theme_package/README.rst.bob
@@ -2,9 +2,9 @@
    If you want to learn more about writing documentation, please check out: http://docs.plone.org/about/documentation_styleguide.html
    This text does not appear on pypi or github. It is a comment.
 
-==============================================================================
+{{% for i in package.dottedname %}}={{% endfor %}}
 {{{ package.dottedname }}}
-==============================================================================
+{{% for i in package.dottedname %}}={{% endfor %}}
 
 Tell me what your product does
 
@@ -38,7 +38,9 @@ This product has been translated into
 Installation
 ------------
 
-Install {{{ package.dottedname }}} by adding it to your buildout::
+Install {{{ package.dottedname }}} by adding it to your buildout
+
+.. code-block:: ini
 
     [buildout]
 
@@ -48,7 +50,7 @@ Install {{{ package.dottedname }}} by adding it to your buildout::
         {{{ package.dottedname }}}
 
 
-and then running ``bin/buildout``
+and then run :command:`bin/buildout`
 
 
 Contribute

--- a/bobtemplates/plone/theme_package/docs/index.rst.bob
+++ b/bobtemplates/plone/theme_package/docs/index.rst.bob
@@ -1,5 +1,5 @@
-====================
+{{% for i in package.dottedname %}}={{% endfor %}}
 {{{ package.dottedname }}}
-====================
+{{% for i in package.dottedname %}}={{% endfor %}}
 
 User documentation


### PR DESCRIPTION
This PR improves the bb template for documentation.

By adding:
``{{% for i in package.dottedname %}}={{% endfor %}}``

We make sure that ``=`` is always the same length as the ``package.dottedname``.

Doing this makes sure we generate valid reST !