### PR TITLE
Use default Travis notifications.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 3.0.0a4 (unreleased)
 --------------------
 
+- Use default Travis notifications.
+  Until now only the creator of the package would get a notification, instead of the committer.
+  Fixes `issue 208 <https://github.com/plone/bobtemplates.plone/issues/208>`_.
+  [maurits]
+
 - Fix coveralls for packages created with addon and theme_package by converting the pickle output of createcoverage in .coverage to json.
   [pbauer]
 

--- a/bobtemplates/plone/addon/.travis.yml.bob
+++ b/bobtemplates/plone/addon/.travis.yml.bob
@@ -27,6 +27,3 @@ after_success:
   - bin/python -m coverage.pickle2json
   - pip install coveralls
   - coveralls
-notifications:
-  email:
-    - {{{ author.email }}}

--- a/bobtemplates/plone/theme_package/.travis.yml.bob
+++ b/bobtemplates/plone/theme_package/.travis.yml.bob
@@ -27,6 +27,3 @@ after_success:
   - bin/python -m coverage.pickle2json
   - pip install coveralls
   - coveralls
-notifications:
-  email:
-    - {{{ author.email }}}


### PR DESCRIPTION
Until now only the creator of the package would get a notification, instead of the committer.
Fixes https://github.com/plone/bobtemplates.plone/issues/208.