### PR TITLE
Use implementer decorator for python3 compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,8 @@ Changelog
 3.6.0b2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Use @implementer decorator instead of implements.
+  [erral]
 
 
 3.6.0b1 (2018-12-28)

--- a/bobtemplates/plone/portlet/portlets/+portlet_name_normalized+.py.bob
+++ b/bobtemplates/plone/portlet/portlets/+portlet_name_normalized+.py.bob
@@ -8,7 +8,7 @@ from plone.portlets.interfaces import IPortletDataProvider
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from z3c.form import field
 from zope.component import getMultiAdapter
-from zope.interface import implements
+from zope.interface import implementer
 
 import json
 import urllib
@@ -24,8 +24,8 @@ class {{{data_provider_class_name}}}(IPortletDataProvider):
     )
 
 
+@implementer({{{data_provider_class_name}}})
 class Assignment(base.Assignment):
-    implements({{{data_provider_class_name}}})
     schema = {{{data_provider_class_name}}}
 
     def __init__(self, place_str='delhi,in'):

--- a/bobtemplates/plone/portlet/portlets/configure.zcml.example.bob
+++ b/bobtemplates/plone/portlet/portlets/configure.zcml.example.bob
@@ -4,7 +4,7 @@
   xmlns:plone="http://namespaces.plone.org/plone">
 
   <include package="plone.app.portlets" />
-  
-  '-*- extra stuff goes here -*-'
+
+  <!-- '-*- extra stuff goes here -*-' -->
 
 </configure>

--- a/package-tests/test_portlet.py
+++ b/package-tests/test_portlet.py
@@ -357,7 +357,7 @@ from plone.portlets.interfaces import IPortletDataProvider
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from z3c.form import field
 from zope.component import getMultiAdapter
-from zope.interface import implements
+from zope.interface import implementer
 
 import json
 import urllib
@@ -373,8 +373,8 @@ class IMyWeatherPortlet(IPortletDataProvider):
     )
 
 
+@implementer(IMyWeatherPortlet)
 class Assignment(base.Assignment):
-    implements(IMyWeatherPortlet)
     schema = IMyWeatherPortlet
 
     def __init__(self, place_str='delhi,in'):


### PR DESCRIPTION
Using ```implements``` is not allowed in python 3 and Plone 5.2:

```
    TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.
```