### PR TITLE
Fix behavior subtemplate: use separate marker interface

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 3.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix behavior template: use separate marker interface, register marker in the
+  behavior zcml and adapt content to the marker, not to IDexterityContent. For
+  further reference, see the plone.behavior README.rst Example 2. fixes #16.
+  [fredvd, jensens]
 
 
 3.6.0 (2019-02-25)

--- a/bobtemplates/plone/behavior.py
+++ b/bobtemplates/plone/behavior.py
@@ -70,7 +70,7 @@ def _update_behaviors_configure_zcml(configurator):
         description="{description}"
         provides=".{normalized_name}.I{klass_name}"
         factory=".{normalized_name}.{klass_name}"
-        marker=".{normalized_name}.I{klass_name}"
+        marker=".{normalized_name}.I{klass_name}Marker"
         />
 
 """.format(

--- a/bobtemplates/plone/behavior/behaviors/+behavior_name_normalized+.py.bob
+++ b/bobtemplates/plone/behavior/behaviors/+behavior_name_normalized+.py.bob
@@ -10,6 +10,9 @@ from zope.interface import implementer
 from zope.interface import provider
 
 
+class I{{{behavior_name_klass}}}Marker:
+    pass
+
 @provider(IFormFieldProvider)
 class I{{{behavior_name_klass}}}(model.Schema):
     """
@@ -23,7 +26,7 @@ class I{{{behavior_name_klass}}}(model.Schema):
 
 
 @implementer(I{{{behavior_name_klass}}})
-@adapter(IDexterityContent)
+@adapter(I{{{behavior_name_klass}}}Marker)
 class {{{behavior_name_klass}}}(object):
     def __init__(self, context):
         self.context = context


### PR DESCRIPTION
Register marker in the behavior zcml and adapt content to the marker.