### PR TITLE
Fix some confusion with 5.1/5.2 - py2/py3 and related

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,9 @@ Changelog
 - Add custom tox2travis.py script, to generate a Travis matrix from Tox configuration.
   [MrTango]
 
+- Fixes #350: add "python_requires" option to setup.py.
+  [jensens, iham]
+
 - Fix some confusion in setup.py classifiers and depenencies due to introduction of Plone 5.2 support.
   Introduces plone.is_plone5.2 variable.
   [jensens]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,9 +40,14 @@ Changelog
 - Add custom tox2travis.py script, to generate a Travis matrix from Tox configuration.
   [MrTango]
 
-- Fix behavior template: use separate marker interface, register marker in the
-  behavior zcml and adapt content to the marker, not to IDexterityContent. For
-  further reference, see the plone.behavior README.rst Example 2. fixes #16.
+- Fix some confusion in setup.py classifiers and depenencies due to introduction of Plone 5.2 support.
+  Introduces plone.is_plone5.2 variable.
+  [jensens]
+
+- Fix behavior template: use separate marker interface,
+  register marker in the behavior zcml and adapt content to the marker, not to IDexterityContent.
+  For further reference, see the plone.behavior README.rst Example 2.
+  Fixes #16.
   [fredvd, jensens]
 
 - Use behavior shortnames in FTI.

--- a/bobtemplates/plone/addon/requirements.txt
+++ b/bobtemplates/plone/addon/requirements.txt
@@ -1,0 +1,3 @@
+-c constraints_plone52.txt
+setuptools
+zc.buildout

--- a/bobtemplates/plone/addon/requirements.txt
+++ b/bobtemplates/plone/addon/requirements.txt
@@ -1,3 +1,0 @@
--c constraints_plone52.txt
-setuptools
-zc.buildout

--- a/bobtemplates/plone/addon/setup.py.bob
+++ b/bobtemplates/plone/addon/setup.py.bob
@@ -54,9 +54,9 @@ setup(
     include_package_data=True,
     zip_safe=False,
 {{% if plone.is_plone52 %}}
-    python_requires="=2.7, >=3.6",
+    python_requires="==2.7, >=3.6",
 {{% else %}}
-    python_requires="=2.7",
+    python_requires="==2.7",
 {{% endif %}}
     install_requires=[
         'setuptools',
@@ -69,7 +69,6 @@ setup(
         'plone.api>=1.8.4',
         'plone.restapi',
 {{% endif %}}
->>>>>>> Fix some confusion in setup.py classifiers and depenencies due to introduction of Plone 5.2 support
 {{% if not plone.is_plone5 %}}
         'plone.app.dexterity<=2.1.1',
         'plone.app.referenceablebehavior',

--- a/bobtemplates/plone/addon/setup.py.bob
+++ b/bobtemplates/plone/addon/setup.py.bob
@@ -21,15 +21,25 @@ setup(
     classifiers=[
         "Environment :: Web Environment",
         "Framework :: Plone",
+        "Framework :: Plone :: Addon",
 {{% if not plone.is_plone5 %}}
         "Framework :: Plone :: 4.3",
 {{% endif %}}
 {{% if plone.is_plone5 %}}
         "Framework :: Plone :: 5.0",
+{{% endif %}}
+{{% if plone.is_plone51 %}}
         "Framework :: Plone :: 5.1",
+{{% endif %}}
+{{% if plone.is_plone52 %}}
+        "Framework :: Plone :: 5.2",
 {{% endif %}}
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
+{{% if plone.is_plone52 %}}
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+{{% endif %}}
         "Operating System :: OS Independent",
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     ],
@@ -44,12 +54,17 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        # -*- Extra requirements: -*-
-        'plone.api>=1.8.4',
-        'Products.GenericSetup>=1.8.2',
         'setuptools',
+        # -*- Extra requirements: -*-
         'z3c.jbot',
+{{% if not (plone.is_plone51 or plone.is_plone52  %}}
+        'Products.GenericSetup>=1.8.2',
+{{% endif %}}
+{{% if not plone.is_plone52 %}}
+        'plone.api>=1.8.4',
         'plone.restapi',
+{{% endif %}}
+>>>>>>> Fix some confusion in setup.py classifiers and depenencies due to introduction of Plone 5.2 support
 {{% if not plone.is_plone5 %}}
         'plone.app.dexterity<=2.1.1',
         'plone.app.referenceablebehavior',
@@ -61,10 +76,12 @@ setup(
     extras_require={
         'test': [
             'plone.app.testing',
+{{% if not plone.is_plone52 %}}
             # Plone KGS does not use this version, because it would break
             # Remove if your package shall be part of coredev.
             # plone_coredev tests as of 2016-04-01.
             'plone.testing>=5.0.0',
+{{% endif %}}
 {{% if plone.is_plone5 %}}
             'plone.app.contenttypes',
 {{% endif %}}

--- a/bobtemplates/plone/addon/setup.py.bob
+++ b/bobtemplates/plone/addon/setup.py.bob
@@ -25,7 +25,7 @@ setup(
 {{% if not plone.is_plone5 %}}
         "Framework :: Plone :: 4.3",
 {{% endif %}}
-{{% if plone.is_plone5 %}}
+{{% if plone.is_plone5 and not plone.is_plone51 and not plone.is_plone52 %}}
         "Framework :: Plone :: 5.0",
 {{% endif %}}
 {{% if plone.is_plone51 %}}
@@ -53,11 +53,16 @@ setup(
     package_dir={'': 'src'},
     include_package_data=True,
     zip_safe=False,
+{{% if plone.is_plone52 %}}
+    python_requires="=2.7, >=3.6",
+{{% else %}}
+    python_requires="=2.7",
+{{% endif %}}
     install_requires=[
         'setuptools',
         # -*- Extra requirements: -*-
         'z3c.jbot',
-{{% if not (plone.is_plone51 or plone.is_plone52  %}}
+{{% if not (plone.is_plone51 or plone.is_plone52) %}}
         'Products.GenericSetup>=1.8.2',
 {{% endif %}}
 {{% if not plone.is_plone52 %}}

--- a/bobtemplates/plone/addon/src/+package.namespace+/+package.name+/tests/test_setup.py.bob
+++ b/bobtemplates/plone/addon/src/+package.namespace+/+package.name+/tests/test_setup.py.bob
@@ -25,7 +25,7 @@ class TestSetup(unittest.TestCase):
     def setUp(self):
         """Custom shared utility setup for tests."""
         self.portal = self.layer['portal']
-{{% if plone.is_plone51 %}}
+{{% if plone.is_plone51 or plone.is_plone52 %}}
         self.installer = get_installer(self.portal, self.layer['request'])
 {{% else %}}
         self.installer = api.portal.get_tool('portal_quickinstaller')
@@ -33,7 +33,7 @@ class TestSetup(unittest.TestCase):
 
     def test_product_installed(self):
         """Test if {{{ package.dottedname }}} is installed."""
-{{% if plone.is_plone51 %}}
+{{% if plone.is_plone51 or plone.is_plone52 %}}
         self.assertTrue(self.installer.is_product_installed(
             '{{{ package.dottedname }}}'))
 {{% else %}}
@@ -57,14 +57,14 @@ class TestUninstall(unittest.TestCase):
 
     def setUp(self):
         self.portal = self.layer['portal']
-{{% if plone.is_plone51 %}}
+{{% if plone.is_plone51 or plone.is_plone52 %}}
         self.installer = get_installer(self.portal, self.layer['request'])
 {{% else %}}
         self.installer = api.portal.get_tool('portal_quickinstaller')
 {{% endif %}}
         roles_before = api.user.get_roles(TEST_USER_ID)
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
-{{% if plone.is_plone51 %}}
+{{% if plone.is_plone51 or plone.is_plone52 %}}
         self.installer.uninstall_product('{{{ package.dottedname }}}')
 {{% else %}}
         self.installer.uninstallProducts(['{{{ package.dottedname }}}'])
@@ -73,7 +73,7 @@ class TestUninstall(unittest.TestCase):
 
     def test_product_uninstalled(self):
         """Test if {{{ package.dottedname }}} is cleanly uninstalled."""
-{{% if plone.is_plone51 %}}
+{{% if plone.is_plone51 or plone.is_plone52 %}}
         self.assertFalse(self.installer.is_product_installed(
             '{{{ package.dottedname }}}'))
 {{% else %}}

--- a/bobtemplates/plone/base.py
+++ b/bobtemplates/plone/base.py
@@ -245,13 +245,13 @@ def set_plone_version_variables(configurator, answer=None):
     if not version:
         return
     if 'plone.is_plone5' not in configurator.variables:
-        # Find out if it is supposed to be Plone 5.
+        # Find out if it is supposed to be Plone 5.0 or higher
         configurator.variables['plone.is_plone5'] = version.startswith('5')
     if 'plone.is_plone51' not in configurator.variables:
-        # Find out if it is supposed to be Plone 5.1 or higher
+        # Find out if it is supposed to be Plone 5.1
         configurator.variables['plone.is_plone51'] = version.startswith('5.1')
     if 'plone.is_plone52' not in configurator.variables:
-        # Find out if it is supposed to be Plone 5.2 or higher
+        # Find out if it is supposed to be Plone 5.2
         configurator.variables['plone.is_plone52'] = version.startswith('5.2')
     if 'plone.minor_version' not in configurator.variables:
         # extract minor version (4.3)

--- a/bobtemplates/plone/base.py
+++ b/bobtemplates/plone/base.py
@@ -246,16 +246,13 @@ def set_plone_version_variables(configurator, answer=None):
         return
     if 'plone.is_plone5' not in configurator.variables:
         # Find out if it is supposed to be Plone 5.
-        if version.startswith('5'):
-            configurator.variables['plone.is_plone5'] = True
-        else:
-            configurator.variables['plone.is_plone5'] = False
+        configurator.variables['plone.is_plone5'] = version.startswith('5')
     if 'plone.is_plone51' not in configurator.variables:
         # Find out if it is supposed to be Plone 5.1 or higher
-        if version.startswith('5.1') or version.startswith('5.2'):
-            configurator.variables['plone.is_plone51'] = True
-        else:
-            configurator.variables['plone.is_plone51'] = False
+        configurator.variables['plone.is_plone51'] = version.startswith('5.1')
+    if 'plone.is_plone52' not in configurator.variables:
+        # Find out if it is supposed to be Plone 5.2 or higher
+        configurator.variables['plone.is_plone52'] = version.startswith('5.2')
     if 'plone.minor_version' not in configurator.variables:
         # extract minor version (4.3)
         # (according to https://plone.org/support/version-support-policy)

--- a/package-tests/test_base.py
+++ b/package-tests/test_base.py
@@ -105,6 +105,20 @@ version=5.1
     base.set_plone_version_variables(configurator)
     assert configurator.variables.get('plone.is_plone5')
     assert not configurator.variables.get('plone.is_plone51')
+    assert not configurator.variables.get('plone.is_plone52')
+    assert configurator.variables.get('plone.minor_version') == '5'
+
+    configurator = Configurator(
+        template='bobtemplates.plone:addon',
+        target_directory=target_dir,
+        variables={
+            'plone.version': '5.2',
+        },
+    )
+    base.set_plone_version_variables(configurator)
+    assert configurator.variables.get('plone.is_plone5')
+    assert not configurator.variables.get('plone.is_plone51')
+    assert not configurator.variables.get('plone.is_plone52')
     assert configurator.variables.get('plone.minor_version') == '5'
 
     configurator = Configurator(
@@ -117,6 +131,7 @@ version=5.1
     base.set_plone_version_variables(configurator)
     assert configurator.variables.get('plone.is_plone5')
     assert configurator.variables.get('plone.is_plone51')
+    assert not configurator.variables.get('plone.is_plone52')
     assert configurator.variables.get('plone.minor_version') == '5.1'
 
     configurator = Configurator(
@@ -129,6 +144,7 @@ version=5.1
     base.set_plone_version_variables(configurator)
     assert not configurator.variables.get('plone.is_plone5')
     assert not configurator.variables.get('plone.is_plone51')
+    assert not configurator.variables.get('plone.is_plone52')
     assert configurator.variables.get('plone.minor_version') == '4.3'
 
 

--- a/package-tests/test_base.py
+++ b/package-tests/test_base.py
@@ -118,8 +118,8 @@ version=5.1
     base.set_plone_version_variables(configurator)
     assert configurator.variables.get('plone.is_plone5')
     assert not configurator.variables.get('plone.is_plone51')
-    assert not configurator.variables.get('plone.is_plone52')
-    assert configurator.variables.get('plone.minor_version') == '5'
+    assert configurator.variables.get('plone.is_plone52')
+    assert configurator.variables.get('plone.minor_version') == '5.2'
 
     configurator = Configurator(
         template='bobtemplates.plone:addon',


### PR DESCRIPTION
- Fixes #346: requirements.txt should point to dist.

- Fixes #350: add "python_requires" option to setup.py.

- Fix some confusion in setup.py classifiers and depenencies due to introduction of Plone 5.2 support.
  Introduces plone.is_plone5.2 variable.
