### PR TITLE
Fix behaviors fti

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,7 +48,11 @@ Changelog
 - Use behavior shortnames in FTI.
   [jensens]
 
-- Do not add dxterity as dependency in Plone 5.x due to the fact it is already in Plone core.
+- Do not add dexterity as dependency in Plone 5.x due to the fact it is already in Plone core.
+  [jensens]
+
+- Do not try to use the main supermodel schema class as behavior.
+  This can work and will lead to warnings.
   [jensens]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,10 +51,6 @@ Changelog
 - Do not add dexterity as dependency in Plone 5.x due to the fact it is already in Plone core.
   [jensens]
 
-- Do not try to use the main supermodel schema class as behavior.
-  This can work and will lead to warnings.
-  [jensens]
-
 - Enforce base class, when supermodel is used, to have a decent marker interface
   [MrTango]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,12 @@ Changelog
   further reference, see the plone.behavior README.rst Example 2. fixes #16.
   [fredvd, jensens]
 
+- Use behavior shortnames in FTI.
+  [jensens]
+
+- Do not add dxterity as dependency in Plone 5.x due to the fact it is already in Plone core.
+  [jensens]
+
 
 3.6.0 (2019-02-25)
 ------------------

--- a/bobtemplates/plone/content_type.py
+++ b/bobtemplates/plone/content_type.py
@@ -224,6 +224,8 @@ def _update_permissions_zcml(configurator):
 
 
 def _update_setup_py(configurator):
+    if configurator.variables['plone.is_plone5']:
+        return
     file_name = u'setup.py'
     file_path = configurator.variables['package.root_folder'] + '/' + file_name
     match_str = '-*- Extra requirements: -*-'

--- a/bobtemplates/plone/content_type/profiles/default/types/+dexterity_type_fti_file_name+.xml.bob
+++ b/bobtemplates/plone/content_type/profiles/default/types/+dexterity_type_fti_file_name+.xml.bob
@@ -51,9 +51,6 @@
 
   <!-- Enabled behaviors -->
   <property name="behaviors" purge="false">
-{{% if not dexterity_type_create_class %}}
-    <element value="{{{ package.dottedname }}}.content.{{{ dexterity_type_name_normalized }}}.I{{{ dexterity_type_name_klass }}}"/>
-{{%  endif %}}
 {{% if dexterity_type_activate_default_behaviors %}}
     <element value="plone.namefromtitle"/>
     <element value="plone.allowdiscussion"/>

--- a/bobtemplates/plone/content_type/profiles/default/types/+dexterity_type_fti_file_name+.xml.bob
+++ b/bobtemplates/plone/content_type/profiles/default/types/+dexterity_type_fti_file_name+.xml.bob
@@ -51,6 +51,9 @@
 
   <!-- Enabled behaviors -->
   <property name="behaviors" purge="false">
+    <!-- Details about all standard behaviors following can be read at
+         https://docs.plone.org/external/plone.app.dexterity/docs/reference/standard-behaviours.html
+    -->
 {{% if dexterity_type_activate_default_behaviors %}}
     <element value="plone.namefromtitle"/>
     <element value="plone.allowdiscussion"/>
@@ -68,26 +71,32 @@
 {{% endif %}}
 {{% endif %}}
 {{% if not dexterity_type_activate_default_behaviors %}}
-    <!--<element value="plone.app.content.interfaces.INameFromTitle"/>-->
-    <!--<element value="plone.app.dexterity.behaviors.discussion.IAllowDiscussion"/>-->
-    <!--<element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation"/>-->
-    <!--<element value="plone.app.dexterity.behaviors.id.IShortName"/>-->
-    <!--<element value="plone.app.dexterity.behaviors.metadata.IOwnership"/>-->
-    <!--<element value="plone.app.dexterity.behaviors.metadata.IPublication"/>-->
-    <!--<element value="plone.app.dexterity.behaviors.metadata.ICategorization"/>-->
-    <!--<element value="plone.app.dexterity.behaviors.metadata.IBasic"/>-->
+    <!-- <element value="plone.namefromtitle"/> -->
+    <!-- <element value="plone.allowdiscussion"/> -->
+    <!-- <element value="plone.excludefromnavigation"/> -->
+    <!-- <element value="plone.shortname"/> -->
+    <!-- <element value="plone.ownership"/> -->
+    <!-- <element value="plone.publication"/> -->
+    <!-- <element value="plone.categorization"/> -->
+    <!-- <element value="plone.basic"/> -->
 {{% if plone.is_plone5 %}}
-    <!--<element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />-->
-    <!--<element value="plone.app.lockingbehavior.behaviors.ILocking" />-->
+    <!-- <element value="plone.locking" /> -->
+    <!-- <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />-->
 {{% else %}}
-    <!--<element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />-->
+    <!-- <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" /> -->
 {{% endif %}}
 {{% endif %}}
-    <!--<element value="plone.app.contenttypes.behaviors.leadimage.ILeadImage"/>-->
-    <!--<element value="plone.app.relationfield.behavior.IRelatedItems"/>-->
-    <!--<element value="plone.app.versioningbehavior.behaviors.IVersionable" />-->
-    <!--<element value="plone.app.contenttypes.behaviors.tableofcontents.ITableOfContents"/>-->
-    <!--<element value="plone.app.contenttypes.behaviors.richtext.IRichText"/>-->
+    <!--<element value="plone.leadimage"/>-->
+    <!--<element value="plone.relateditems"/>-->
+    <!--<element value="plone.richtext"/>-->
+    <!--<element value="plone.tableofcontents"/>-->
+    <!--<element value="plone.versionable" />-->
+{{% if dexterity_type_base_class == "Container" %}}
+    <!--<element value="plone.nextprevioustoggle" />-->
+    <!--<element value="plone.nextpreviousenabled" />-->
+    <!--<element value="plone.navigationroot" />-->
+    <!--<element value="plone.selectablecontrainstypes" />-->
+{{% endif %}}
   </property>
 
   <!-- View information -->

--- a/bobtemplates/plone/content_type/profiles/default/types/+dexterity_type_fti_file_name+.xml.bob
+++ b/bobtemplates/plone/content_type/profiles/default/types/+dexterity_type_fti_file_name+.xml.bob
@@ -55,17 +55,17 @@
     <element value="{{{ package.dottedname }}}.content.{{{ dexterity_type_name_normalized }}}.I{{{ dexterity_type_name_klass }}}"/>
 {{%  endif %}}
 {{% if dexterity_type_activate_default_behaviors %}}
-    <element value="plone.app.content.interfaces.INameFromTitle"/>
-    <element value="plone.app.dexterity.behaviors.discussion.IAllowDiscussion"/>
-    <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation"/>
-    <element value="plone.app.dexterity.behaviors.id.IShortName"/>
-    <element value="plone.app.dexterity.behaviors.metadata.IOwnership"/>
-    <element value="plone.app.dexterity.behaviors.metadata.IPublication"/>
-    <element value="plone.app.dexterity.behaviors.metadata.ICategorization"/>
-    <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
+    <element value="plone.namefromtitle"/>
+    <element value="plone.allowdiscussion"/>
+    <element value="plone.excludefromnavigation"/>
+    <element value="plone.shortname"/>
+    <element value="plone.ownership"/>
+    <element value="plone.publication"/>
+    <element value="plone.categorization"/>
+    <element value="plone.basic"/>
 {{% if plone.is_plone5 %}}
+    <element value="plone.locking" />
     <!--<element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />-->
-    <element value="plone.app.lockingbehavior.behaviors.ILocking" />
 {{% else %}}
     <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />
 {{% endif %}}


### PR DESCRIPTION
- Use behavior shortnames in FTI. see #345 

- Do not add dexterity as dependency in Plone 5.x due to the fact it is already in Plone core.

- Do not try to use the main supermodel schema class as behavior.
  This can not work and will lead to warnings.