### PR TITLE
Remove version conditions for addon dependencies, p43-p52 should be s…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-4.1 (unreleased)
+4.0.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Remove version conditions for addon dependencies, p43-p52 should be supported.
+  [MrTango]
 
 
 4.0 (2019-03-11)
@@ -31,7 +32,7 @@ Changelog
 - Add Sphinx doc config to addon template docs.
   [MrTango]
 
-- Make portlet sub-template Python compatible.
+- Make portlet sub-template Python 3 compatible.
   [MrTango]
 
 - Remove skeleton test for theme_barceloneta on Plone 4

--- a/bobtemplates/plone/addon/setup.py.bob
+++ b/bobtemplates/plone/addon/setup.py.bob
@@ -62,14 +62,18 @@ setup(
         'setuptools',
         # -*- Extra requirements: -*-
         'z3c.jbot',
+{{% if not (plone.is_plone51 or plone.is_plone52) %}}
         'Products.GenericSetup>=1.8.2',
-        'plone.api',
+{{% endif %}}
+        'plone.api>=1.8.4',
         'plone.restapi',
         'plone.app.dexterity',
+{{% if not plone.is_plone5 %}}
         'plone.app.referenceablebehavior',
         'plone.app.relationfield',
         'plone.app.lockingbehavior',
         'plone.schema',
+{{% endif %}}
     ],
     extras_require={
         'test': [

--- a/bobtemplates/plone/addon/setup.py.bob
+++ b/bobtemplates/plone/addon/setup.py.bob
@@ -62,30 +62,22 @@ setup(
         'setuptools',
         # -*- Extra requirements: -*-
         'z3c.jbot',
-{{% if not (plone.is_plone51 or plone.is_plone52) %}}
         'Products.GenericSetup>=1.8.2',
-{{% endif %}}
-{{% if not plone.is_plone52 %}}
-        'plone.api>=1.8.4',
+        'plone.api',
         'plone.restapi',
-{{% endif %}}
-{{% if not plone.is_plone5 %}}
-        'plone.app.dexterity<=2.1.1',
+        'plone.app.dexterity',
         'plone.app.referenceablebehavior',
         'plone.app.relationfield',
         'plone.app.lockingbehavior',
         'plone.schema',
-{{% endif %}}
     ],
     extras_require={
         'test': [
             'plone.app.testing',
-{{% if not plone.is_plone52 %}}
             # Plone KGS does not use this version, because it would break
             # Remove if your package shall be part of coredev.
             # plone_coredev tests as of 2016-04-01.
             'plone.testing>=5.0.0',
-{{% endif %}}
 {{% if plone.is_plone5 %}}
             'plone.app.contenttypes',
 {{% endif %}}

--- a/bobtemplates/plone/addon/test_plone43.cfg
+++ b/bobtemplates/plone/addon/test_plone43.cfg
@@ -13,6 +13,7 @@ setuptools = 27.3.0
 # Pillow = 5.1.0
 
 # manual pinnings
+plone.app.dexterity = <=2.1.1
 docutils = 0.14
 plone.app.robotframework = 1.2.1
 configparser = 3.5.3

--- a/bobtemplates/plone/addon/tox.ini
+++ b/bobtemplates/plone/addon/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,37}-lint,
+    {py27,py37}-lint,
     py{27}-Plone{43,51},
     py{27,37}-Plone{52},
     build_instance,


### PR DESCRIPTION
…upported

This is makes sense, because the generated package should be useable for
Plone version from 4.3 until current. If someone wants to drop support,
she can remove some of the dependencies, as they are in Plone core in
newer versions.