### PR TITLE
Add dist to .gitignore

### DIFF
--- a/bobtemplates/plone/addon/.gitignore.bob
+++ b/bobtemplates/plone/addon/.gitignore.bob
@@ -16,6 +16,7 @@ local/
 node_modules/
 parts/
 src/*
+dist/*
 test.plone_addon/
 var/
 # files


### PR DESCRIPTION
dist folder gets created when releasing (with jarn.mkrelease at least)