### PR TITLE
allow Gruntfile.js and package.json

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 4.0.5 (unreleased)
 ------------------
 
+- Remove Gruntfile.js and package.json from .gitignore in addon package.
+  [erral]
+
 - ReST fomatting and fix typo in README.rst
 
 

--- a/bobtemplates/plone/addon/.gitignore.bob
+++ b/bobtemplates/plone/addon/.gitignore.bob
@@ -22,11 +22,9 @@ var/
 # files
 .installed.cfg
 .mr.developer.cfg
-Gruntfile.js
 lib64
 log.html
 output.xml
-package.json
 pip-selfcheck.json
 report.html
 .vscode/


### PR DESCRIPTION
Remove Gruntfile.js and package.json from .gitignore, one may want to have them checked-in into git when using from instance the theme_barceloneta package or using some other modules in an addon.