### PR TITLE
Fix travis setup: geckodriver & coveralls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 4.1.4 (unreleased)
 ------------------
 
+- Run coveralls in the correct path
+  [erral]
+
 - Fix 'geckodriver' error when running tests in Travis.
   [erral]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 4.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix 'geckodriver' error when running tests in Travis.
+  [erral]
 
 
 4.1.3 (2019-08-31)

--- a/bobtemplates/plone/addon/.travis.yml.bob
+++ b/bobtemplates/plone/addon/.travis.yml.bob
@@ -37,6 +37,9 @@ install:
   - bin/buildout -N -t 3 code-analysis:return-status-codes=True
 
 before_script:
+- wget "https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz"
+- tar xfz geckodriver-v0.24.0-linux64.tar.gz
+- sudo mv geckodriver /usr/local/bin
 - 'export DISPLAY=:99.0'
 - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 - sleep 3

--- a/bobtemplates/plone/addon/.travis.yml.bob
+++ b/bobtemplates/plone/addon/.travis.yml.bob
@@ -55,4 +55,4 @@ after_success:
   - bin/pip install coverage
   - bin/python -m coverage.pickle2json
   - bin/pip install -q coveralls
-  - coveralls
+  - bin/coveralls


### PR DESCRIPTION
As reported on Community Forum, when a newly created package is run in Travis a 'geckodriver is missing in PATH' error is created. 

https://community.plone.org/t/travis-ci-test-failed-with-geckodriver-executable-needs-to-be-in-path/9071

Also, run coveralls from the created bin directory.