### PR TITLE
Fixed name of commented out version behavior.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 4.1.4 (unreleased)
 ------------------
 
+- Fixed name of commented out version behavior.
+  This is ``plone.versioning`` and not ``plone.versionable``.
+  [maurits]
+
 - Run coveralls in the correct path
   [erral]
 

--- a/bobtemplates/plone/content_type/profiles/default/types/+dexterity_type_fti_file_name+.xml.bob
+++ b/bobtemplates/plone/content_type/profiles/default/types/+dexterity_type_fti_file_name+.xml.bob
@@ -90,7 +90,7 @@
     <!--<element value="plone.relateditems"/>-->
     <!--<element value="plone.richtext"/>-->
     <!--<element value="plone.tableofcontents"/>-->
-    <!--<element value="plone.versionable" />-->
+    <!--<element value="plone.versioning" />-->
     <!--<element value="plone.translatable" />-->
 {{% if dexterity_type_base_class == "Container" %}}
     <!--<element value="plone.nextprevioustoggle" />-->


### PR DESCRIPTION
This is `plone.versioning` and not `plone.versionable`. When I uncommented the behavior in an add-on, I got errors in the log:

    Error resolving behavior plone.versionable

Fixes one part of issue #391.