### PR TITLE
Fixed Travis caching.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 4.1.4 (unreleased)
 ------------------
 
+- Fixed Travis caching.  Downloads do not need to be cached.
+  And for the eggs we were caching the wrong directory.
+  Fixes `issue #408 <https://github.com/plone/bobtemplates.plone/issues/408>`_.
+  [maurits]
+
 - Fixed name of commented out version behavior.
   This is ``plone.versioning`` and not ``plone.versionable``.
   [maurits]

--- a/bobtemplates/plone/addon/.travis.yml.bob
+++ b/bobtemplates/plone/addon/.travis.yml.bob
@@ -5,7 +5,6 @@ cache:
   pip: true
   directories:
   - eggs
-  - downloads
 python:
   - "2.7"
 matrix:
@@ -23,14 +22,7 @@ matrix:
 before_install:
   - sudo apt-get install -y firefox-geckodriver
   - virtualenv -p `which python` .
-  - mkdir -p $HOME/buildout-cache/{eggs,downloads}
-  - mkdir $HOME/.buildout
-  - echo "[buildout]" > $HOME/.buildout/default.cfg
-  - echo "download-cache = $HOME/buildout-cache/downloads" >> $HOME/.buildout/default.cfg
-  - echo "eggs-directory = $HOME/buildout-cache/eggs" >> $HOME/.buildout/default.cfg
   - bin/pip install -r requirements.txt -c constraints_plone$PLONE_VERSION.txt
-#  - bin/buildout -N out:download-cache=downloads code-analysis:return-status-codes=True annotate
-#  - bin/buildout -N buildout:download-cache=downloads code-analysis:return-status-codes=True
   - cp test_plone$PLONE_VERSION.cfg buildout.cfg
 
 install:

--- a/bobtemplates/plone/theme_package/.travis.yml.bob
+++ b/bobtemplates/plone/theme_package/.travis.yml.bob
@@ -1,10 +1,10 @@
+dist: bionic
 language: python
 sudo: false
 cache:
   pip: true
   directories:
   - eggs
-  - downloads
 python:
   - "2.7"
 matrix:
@@ -12,8 +12,8 @@ matrix:
 install:
   - virtualenv -p `which python` .
   - bin/pip install -r requirements.txt
-  - bin/buildout -N buildout:download-cache=downloads code-analysis:return-status-codes=True annotate
-  - bin/buildout -N buildout:download-cache=downloads code-analysis:return-status-codes=True
+  - bin/buildout -N code-analysis:return-status-codes=True annotate
+  - bin/buildout -N code-analysis:return-status-codes=True
 before_script:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
Downloads do not need to be cached.
And for the eggs we were caching the wrong directory.
Fixes issue #408.

Also let plone/theme_package use a bionic machine on Travis, so the config is more similar to plone/addon.