### PR TITLE
Optimize buildout config for project buildouts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,9 @@ Changelog
 - Automatically fix isort issues after using addon template.
   [MrTango]
 
+- Improve buildout template, it's now using Plone release versions rather than buildouttesting.
+  [MrTango]
+
 
 5.0.4 (2019-11-28)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Provided templates
 
 - addon
 - theme_package (Deprecated, use theme_barceloneta subtemplate)
-- buildout
+- buildout (useful setup a development buildout or to test new pending Plone versions)
 
 
 Provided subtemplates

--- a/bobtemplates/plone/buildout/.mrbob.ini
+++ b/bobtemplates/plone/buildout/.mrbob.ini
@@ -6,8 +6,8 @@ python.version.default = python3.7
 
 plone.version.question = Plone version for the buildout
 plone.version.required = True
-plone.version.default = 5.2
-plone.version.help = Define the Plone version /5.1.6/5.1/5.2 aso
+plone.version.default = 5.2.1
+plone.version.help = Define the Plone version /5.1.6/5.2.1 aso
 
 plone.instance_address.question = Address for the Plone instance [localhost:8080]
 plone.instance_address.required = True
@@ -25,6 +25,13 @@ plone.wsgi.default = on
 plone.wsgi.post_ask_question = mrbob.hooks:validate_choices
 plone.wsgi.choices = on|off
 plone.wsgi.choices_delimiter = |
+
+vscode_support.question = Do you want me to activate VS Code support? (y/n)
+vscode_support.help = This installs collective.recipe.vscode for better support of VS Code editor.
+vscode_support.default = y
+vscode_support.post_ask_question = mrbob.hooks:validate_choices mrbob.hooks:to_boolean
+vscode_support.choices = y|n
+vscode_support.choices_delimiter = |
 
 
 

--- a/bobtemplates/plone/buildout/.mrbob.ini
+++ b/bobtemplates/plone/buildout/.mrbob.ini
@@ -1,8 +1,31 @@
 [questions]
-plone.version.question = Plone version for buildout.plonetest
+python.version.question = Python binary for virtualenv ('python2.7', 'python3.7')
+python.version.required = True
+python.version.help = Which Python version would you like to use for the virtualenv to create?
+python.version.default = python3.7
+
+plone.version.question = Plone version for the buildout
 plone.version.required = True
-plone.version.default = 5.1.x
-plone.version.help = Define the Plone version (buildout.plonetest) 5.0.x/5.1.x/5.x/4.3.x
+plone.version.default = 5.2
+plone.version.help = Define the Plone version /5.1.6/5.1/5.2 aso
+
+plone.instance_address.question = Address for the Plone instance [localhost:8080]
+plone.instance_address.required = True
+plone.instance_address.help = You can define the hostname/IP and port for the Plone instance to listen on
+plone.instance_address.default = 127.0.0.1:8080
+
+plone.initial_admin_password.question = Initial Zope admin password
+plone.initial_admin_password.required = True
+plone.initial_admin_password.help = Password for the Zope admin user, used to create Plone sites.
+
+plone.wsgi.question = Use WSGI to run Plone
+plone.wsgi.required = True
+plone.wsgi.help = You can run Plone in WSGI mode or in ZServer mode
+plone.wsgi.default = on
+plone.wsgi.post_ask_question = mrbob.hooks:validate_choices
+plone.wsgi.choices = on|off
+plone.wsgi.choices_delimiter = |
+
 
 
 [template]

--- a/bobtemplates/plone/buildout/base.cfg.bob
+++ b/bobtemplates/plone/buildout/base.cfg.bob
@@ -1,0 +1,228 @@
+######################################################
+# Base Configuration; this provides sane defaults
+# for commonly used parts.
+# ---------------------------------------------------
+#
+# Buildout instructions in this file are
+# usually only changed by experienced developers.
+#
+# Beyond here there be dragons!
+
+[buildout]
+# eggs-directory=../buildout-cache/eggs
+# download-cache=../buildout-cache/downloads
+
+# Don't download new things unless needed to satisfy dependencies.
+# Override this on the command line with the "-n" flag.
+newest = false
+
+# pick final releases over newer development releases
+prefer-final = true
+
+# show picked versions wherever we do an automatic choice
+show-picked-versions = true
+
+versions = versions
+
+# Add additional egg download sources here. dist.plone.org contains archives
+# of Plone packages.
+find-links =
+    http://dist.plone.org
+    http://effbot.org/downloads
+
+############################################
+# Environment Variables
+# ---------------------
+# Some of the behavior of your Zope/Plone instances are controlled with OS
+# environment variables. You may set those here in a key / value format.
+# Some common settings:
+#    * TZ allows you to set a time zone for systems where it's not
+#      automatically available.
+#    * zope_i18n_compile_mo_files allows for automatic compilation of
+#      missing translation files (may slow startup).
+#    * zope_i18n_allowed_languages allows you to limit the available
+#      translations.
+#    * PYTHON_EGG_CACHE determines where zipped python packages are unpacked
+#      for use.
+#    * PYTHONHASHSEED determines initial seed for hashes. "random" causes a
+#      pseudo-random value is used to seed the hashes of str, bytes and datetime
+#      objects.
+environment-vars =
+    zope_i18n_compile_mo_files true
+    PYTHON_EGG_CACHE ${buildout:directory}/var/.python-eggs
+#    PYTHONHASHSEED random
+#    TZ US/Eastern
+#    zope_i18n_allowed_languages en es de fr
+
+[instance_base]
+# Use this section to install and configure a Zope operating
+# instance.
+# For options see http://pypi.python.org/pypi/plone.recipe.zope2instance
+
+# The line below sets only the initial password. It will not change an
+# existing password.
+user = ${buildout:user}
+# change debug-mode to "on" to run in development mode.
+# starting in foreground (fg) mode is a better way to do this.
+debug-mode = off
+# change verbose-security to "on" for detailed security
+# errors while developing
+verbose-security = ${buildout:verbose-security}
+# change deprecation-warnings to "on" to get log warnings
+# for deprecated usages.
+# deprecation-warnings = ${buildout:deprecation-warnings}
+
+# With Plone 5.2+, we default to wsgi
+wsgi = {{{ plone.wsgi }}}
+
+# storage locations
+var = ${buildout:var-dir}
+blob-storage = ${:var}/blobstorage
+
+# Comment the next four lines out if you don't need
+# automatic log rotation for event and access logs.
+event-log-max-size = 5 MB
+event-log-old-files = 5
+access-log-max-size = 20 MB
+access-log-old-files = 5
+
+# If you want Zope to know about any additional eggs, list them here.
+# e.g. eggs = ${buildout:eggs} my.package
+eggs =
+    ${buildout:eggs}
+
+# If you want to register ZCML slugs for any packages, list them here.
+# e.g. zcml = my.package my.other.package
+zcml = ${buildout:zcml}
+
+# You may also control the environment variables for the instance.
+environment-vars = ${buildout:environment-vars}
+
+[zeoserver_base]
+# Use this section to install and configure a Zope
+# Enterprise Objects server.
+# For options see http://pypi.python.org/pypi/plone.recipe.zeoserver
+#
+# Set storage
+var = ${buildout:var-dir}
+blob-storage = ${buildout:var-dir}/blobstorage
+# Put the log, pid and socket files in var/zeoserver
+zeo-log     = ${buildout:var-dir}/zeoserver/zeoserver.log
+pid-file    = ${buildout:var-dir}/zeoserver/zeoserver.pid
+socket-name = ${buildout:var-dir}/zeoserver/zeo.zdsock
+
+[client_base]
+# Use this section to install and configure a ZEO client
+# instance.
+# For options see http://pypi.python.org/pypi/plone.recipe.zope2instance
+
+# The line below sets only the initial password. It will not change an
+# existing password.
+user = ${buildout:user}
+# change debug-mode to "on" to run in development mode.
+# starting in foreground (fg) mode is a better way to do this.
+debug-mode = off
+# change verbose-security to "on" for detailed security
+# errors while developing
+verbose-security = ${buildout:verbose-security}
+# change deprecation-warnings to "on" to get log warnings
+# for deprecated usages.
+deprecation-warnings = ${buildout:deprecation-warnings}
+
+# With Plone 5.2+, we default to wsgi
+wsgi = {{{ plone.wsgi }}}
+
+# base locations
+var = ${buildout:var-dir}
+blob-storage = ${:var}/blobstorage
+
+# Comment the next four lines out if you don't need
+# automatic log rotation for event and access logs.
+event-log-max-size = 5 MB
+event-log-old-files = 5
+access-log-max-size = 20 MB
+access-log-old-files = 5
+
+# If you want Zope to know about any additional eggs, list them here.
+# e.g. eggs = ${buildout:eggs} my.package
+eggs =
+    ${buildout:eggs}
+
+# If you want to register ZCML slugs for any packages, list them here.
+# e.g. zcml = my.package my.other.package
+zcml = ${buildout:zcml}
+
+# You may also control the environment variables for the instance.
+environment-vars = ${buildout:environment-vars}
+
+zeo-client = true
+# shared blobs are much faster if we're on the same server.
+# if not, turn it off.
+shared-blob = on
+
+# defer early binding to port; may improve load balancer behavior on restarts
+http-fast-listen = off
+
+# Put the log, pid, lock files in var/client1
+event-log = ${buildout:var-dir}/${:_buildout_section_name_}/event.log
+z2-log    = ${buildout:var-dir}/${:_buildout_section_name_}/Z2.log
+pid-file  = ${buildout:var-dir}/${:_buildout_section_name_}/${:_buildout_section_name_}.pid
+lock-file = ${buildout:var-dir}/${:_buildout_section_name_}/${:_buildout_section_name_}.lock
+
+[repozo]
+# This recipe builds the repozo script for non-zeo installations.
+recipe = zc.recipe.egg
+eggs = ZODB
+scripts = repozo
+
+[backup]
+# This recipe builds the backup, restore and snapshotbackup commands.
+# For options see http://pypi.python.org/pypi/collective.recipe.backup
+recipe = collective.recipe.backup
+location = ${buildout:backups-dir}/backups
+blobbackuplocation = ${buildout:backups-dir}/blobstoragebackups
+snapshotlocation = ${buildout:backups-dir}/snapshotbackups
+blobsnapshotlocation = ${buildout:backups-dir}/blobstoragesnapshots
+datafs = ${buildout:var-dir}/filestorage/Data.fs
+blob-storage = ${buildout:var-dir}/blobstorage
+
+[setpermissions]
+# This recipe is used to set permissions for root mode installs
+# For options see http://pypi.python.org/pypi/plone.recipe.command
+recipe = plone.recipe.command
+command =
+    # Dummy references to force this to execute after referenced parts
+    echo ${backup:location} ${unifiedinstaller:need-sudo} > /dev/null
+    chmod 600 .installed.cfg
+    # Make sure anything we've created in var is r/w by our group
+    find ${buildout:var-dir} -type d -exec chmod 770 {} \; 2> /dev/null
+    find ${buildout:var-dir} -type f -exec chmod 660 {} \; 2> /dev/null
+    find ${buildout:backups-dir} -type d -exec chmod 770 {} \; 2> /dev/null
+    find ${buildout:backups-dir} -type f -exec chmod 660 {} \; 2> /dev/null
+    chmod 754 ${buildout:directory}/bin/*
+update-command = ${:command}
+
+[zopepy]
+# installs a zopepy python interpreter that runs with your
+# full Zope environment
+recipe = zc.recipe.egg
+eggs = ${buildout:eggs}
+interpreter = zopepy
+scripts = zopepy
+
+[unifiedinstaller]
+# This recipe installs the plonectl script and a few other convenience
+# items.
+# For options see http://pypi.python.org/pypi/plone.recipe.unifiedinstaller
+recipe = plone.recipe.unifiedinstaller
+user = ${buildout:user}
+buildout-user = ${buildout:buildout-user}
+need-sudo = ${buildout:need-sudo}
+
+[precompiler]
+# This recipe is used in production installs to compile
+# .py and .po files so that the daemon doesn't try to do it.
+# For options see http://pypi.python.org/pypi/plone.recipe.precompiler
+recipe = plone.recipe.precompiler
+eggs = ${buildout:eggs}
+compile-mo-files = true

--- a/bobtemplates/plone/buildout/base.cfg.bob
+++ b/bobtemplates/plone/buildout/base.cfg.bob
@@ -226,3 +226,8 @@ need-sudo = ${buildout:need-sudo}
 recipe = plone.recipe.precompiler
 eggs = ${buildout:eggs}
 compile-mo-files = true
+
+[vscode]
+recipe = collective.recipe.vscode
+eggs = ${instance:eggs}
+autocomplete-use-omelette = True

--- a/bobtemplates/plone/buildout/bobtemplate.cfg.bob
+++ b/bobtemplates/plone/buildout/bobtemplate.cfg.bob
@@ -1,3 +1,4 @@
 [main]
 version = {{{ plone.version }}}
 template = buildout
+python = {{{ python.version }}}

--- a/bobtemplates/plone/buildout/buildout.cfg.bob
+++ b/bobtemplates/plone/buildout/buildout.cfg.bob
@@ -38,7 +38,11 @@ parts =
     repozo
     backup
     zopepy
-#    unifiedinstaller
+{{% if vscode_support %}}
+    vscode
+{{% else %}}
+#    vscode
+{{% endif %}}
 
 
 [instance]

--- a/bobtemplates/plone/buildout/buildout.cfg.bob
+++ b/bobtemplates/plone/buildout/buildout.cfg.bob
@@ -1,46 +1,50 @@
 [buildout]
-extends =
-    https://raw.github.com/collective/buildout.plonetest/master/test-{{{ plone.version }}}.cfg
-    https://raw.github.com/collective/buildout.plonetest/master/qa.cfg
-    https://raw.github.com/plone/plone.app.robotframework/master/versions.cfg
 
+# makes sure you're not running buildout as root.
 extensions =
     buildout.sanitycheck
-    mr.developer
 
-# mr.developer settings:
-auto-checkout = *
-always-checkout = true
-
-versions = versions
-extensions = mr.developer
-
-parts = 
-    test
+extends =
+    base.cfg
+    http://dist.plone.org/release/{{{ plone.version }}}/versions.cfg
 
 
-eggs +=
+find-links +=
+    http://dist.plone.org/release/{{{ plone.version }}}
+
+
+eggs =
+    Plone
+    Pillow
+
+
+zcml =
+#    plone.reload
 
 
 develop =
+#    src/my.package
 
 
-auto-checkout = *
-# always-checkout = true
+var-dir=${buildout:directory}/var
+backups-dir=${buildout:var-dir}
+user=admin:{{{ plone.initial_admin_password }}}
+deprecation-warnings = off
+verbose-security = off
 
 
-[sources]
-# my.package = git git@github.com:collective/collective.easyform.git
+parts =
+    instance
+    repozo
+    backup
+    zopepy
+#    unifiedinstaller
+
+
+[instance]
+<= instance_base
+recipe = plone.recipe.zope2instance
+http-address = {{{ plone.instance_address }}}
 
 
 [versions]
-zc.buildout =
-setuptools =
-
-
-[test]
-recipe = zc.recipe.testrunner
-defaults = ['--auto-color', '--auto-progress']
-eggs =
-    Plone
-    ${buildout:eggs}

--- a/bobtemplates/plone/buildout/constraints.txt.bob
+++ b/bobtemplates/plone/buildout/constraints.txt.bob
@@ -1,0 +1,1 @@
+-c https://dist.plone.org/release/{{{ plone.version }}}/requirements.txt

--- a/bobtemplates/plone/buildout/requirements.txt
+++ b/bobtemplates/plone/buildout/requirements.txt
@@ -1,2 +1,3 @@
-setuptools==38.5.1
-zc.buildout==2.11.0
+-c constraints.txt
+setuptools
+zc.buildout

--- a/docs/develop.rst
+++ b/docs/develop.rst
@@ -216,7 +216,7 @@ Increase verbosity of Tox/Pytest
 
 .. code-block:: shell
 
-    tox -e py36-packagetests -vv -- -s
+    tox -e py37-packagetests -vv -- -s
 
 Package tests
 .............


### PR DESCRIPTION
Optimize buildout config for development projects or even smal production buildouts. It's now using official Plone releases rather than using buildout.plonetest versions. You can now also use it to quick setup a buildout to test out a new pending Plone version, by setting the Plone version to something like this: "5.2.2-pending".