### PR TITLE
Align template's setup.cfg to the projects one.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 5.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Align template's setup.cfg to the projects one.
+  Especially raises the flake8 line-length to black default.
+  [thet]
 
 
 5.0.4 (2019-11-28)

--- a/bobtemplates/plone/addon/setup.cfg.bob
+++ b/bobtemplates/plone/addon/setup.cfg.bob
@@ -12,8 +12,21 @@ force_alphabetical_sort = True
 force_single_line = True
 lines_after_imports = 2
 line_length = 200
-not_skip = __init__.py
+not_skip =
+    __init__.py
+skip =
 
 [flake8]
+ignore =
+    W503,
+    C812,
+    E501
+    T001
+    C813
+# E203, E266
 exclude = bootstrap.py,docs,*.egg.,omelette
-max-complexity = 15
+max-line-length = 88
+max-complexity = 18
+select = B,C,E,F,W,T4,B9
+
+builtins = unicode,basestring

--- a/bobtemplates/plone/theme_package/setup.cfg.bob
+++ b/bobtemplates/plone/theme_package/setup.cfg.bob
@@ -12,4 +12,21 @@ force_alphabetical_sort = True
 force_single_line = True
 lines_after_imports = 2
 line_length = 200
-not_skip = __init__.py
+not_skip =
+    __init__.py
+skip =
+
+[flake8]
+ignore =
+    W503,
+    C812,
+    E501
+    T001
+    C813
+# E203, E266
+exclude = bootstrap.py,docs,*.egg.,omelette
+max-line-length = 88
+max-complexity = 18
+select = B,C,E,F,W,T4,B9
+
+builtins = unicode,basestring


### PR DESCRIPTION
Especially raises the flake8 line-length to black default.