### PR TITLE
Fix flake8 failures in plone/addon... locales/update.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ Changelog
 - Fix flake8 missing trailing comma, format call uses missing keyword, provides unused keyword
   [fulv]
 
+
 5.0.4 (2019-11-28)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Changelog
 - Add collective.recipe.vscode to addon base.cfg, activated by default, we have a question to disable it.
   [MrTango]
 
+- Fix flake8 missing trailing comma, format call uses missing keyword, provides unused keyword
+  [fulv]
 
 5.0.4 (2019-11-28)
 ------------------

--- a/bobtemplates/plone/addon/src/+package.namespace+/+package.name+/locales/update.py.bob
+++ b/bobtemplates/plone/addon/src/+package.namespace+/+package.name+/locales/update.py.bob
@@ -46,7 +46,7 @@ def _rebuild():
         locale_path=locale_path,
         domain=domain,
         target_path=target_path,
-        exclude=excludes
+        excludes=excludes,
     )
     subprocess.call(
         cmd,


### PR DESCRIPTION
Fixes issue #405 

```
$ python --version 2> /dev/stdout | grep 3.6 || bin/code-analysis
Flake8..........................[ FAILURE ] in 0.533s
/home/travis/build/collective/collective.pat_clippable/src/collective/pat_clippable/locales/update.py:44:11: P202 format call uses missing keyword (excludes)
/home/travis/build/collective/collective.pat_clippable/src/collective/pat_clippable/locales/update.py:44:11: P302 format call provides unused keyword (exclude)
/home/travis/build/collective/collective.pat_clippable/src/collective/pat_clippable/locales/update.py:49:25: C812 missing trailing comma
The command "bin/code-analysis" exited with 1 in 0.534s.
The command "python --version 2> /dev/stdout | grep 3.6 || bin/code-analysis" exited with 1.
```