### PR TITLE
Remove Travis configuration sudo false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 *.egg-info
 *.mo
+.*project
 *.py[cod]
 # dirs
 bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 dist: xenial
 python: 2.7
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove Travis configuration sudo false.
+  [wesleybl]
 
 
 5.1.2 (2020-10-14)

--- a/bobtemplates/plone/addon/.travis.yml.bob
+++ b/bobtemplates/plone/addon/.travis.yml.bob
@@ -1,6 +1,5 @@
 dist: bionic
 language: python
-sudo: false
 cache:
   pip: true
   directories:

--- a/bobtemplates/plone/theme_package/.travis.yml.bob
+++ b/bobtemplates/plone/theme_package/.travis.yml.bob
@@ -1,6 +1,5 @@
 dist: bionic
 language: python
-sudo: false
 cache:
   pip: true
   directories:


### PR DESCRIPTION
It's deprecated:

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Fix #193 