### PR TITLE
Force setuptools>44.1.0 on tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,13 +24,7 @@ pip-selfcheck.json
 coverage.xml
 Vagrantfile
 .DS_Store
-
-# excludes / This Files should go into version control
-!.editorconfig
-!.gitattributes
-!.gitignore
-!.gitkeep
-!.travis.yml
+/.settings
 
 /dist/
 /.idea/

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,9 @@ envlist =
 
 skip_missing_interpreters = True
 
+# setuptools>44.1.0 is required to install pdbpp on Python 2.7 in Travis.
+requires = setuptools>44.1.0
+
 [testenv]
 usedevelop = True
 extras =


### PR DESCRIPTION
`setuptools>44.1.0` is required to install `pdbpp` on Python 2.7 in Travis.

This fix the error:

```shell
Collecting pdbpp
  Using cached https://files.pythonhosted.org/packages/3f/82/4b6c5b9128bbbad48a52c6d639c84e3c453e75953ed123b6e9338420dcec/pdbpp-0.10.2.tar.gz
    Complete output from command python setup.py egg_info:
    /tmp/easy_install-_5oGNO/setuptools_scm-6.0.1/src
    <pkg_resources.WorkingSet object at 0x7fdceee51550>
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-PPBNJB/pdbpp/setup.py", line 100, in <module>
        'install_pth_hack': install_pth_hack,
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/__init__.py", line 139, in setup
        _install_setup_requires(attrs)
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/__init__.py", line 134, in _install_setup_requires
        dist.fetch_build_eggs(dist.setup_requires)
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/dist.py", line 514, in fetch_build_eggs
        replace_conflicting=True,
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/pkg_resources/__init__.py", line 777, in resolve
        replace_conflicting=replace_conflicting
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1060, in best_match
        return self.obtain(req, installer)
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1072, in obtain
        return installer(requirement)
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/dist.py", line 581, in fetch_build_egg
        return cmd.easy_install(req)
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 676, in easy_install
        return self.install_item(spec, dist.location, tmpdir, deps)
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 702, in install_item
        dists = self.install_eggs(spec, download, tmpdir)
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 887, in install_eggs
        return self.build_and_install(setup_script, setup_base)
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 1155, in build_and_install
        self.run_setup(setup_script, setup_base, args)
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 1141, in run_setup
        run_setup(setup_script, args)
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/sandbox.py", line 253, in run_setup
        raise
      File "/opt/python/2.7.15/lib/python2.7/contextlib.py", line 35, in __exit__
        self.gen.throw(type, value, traceback)
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/sandbox.py", line 195, in setup_context
        yield
      File "/opt/python/2.7.15/lib/python2.7/contextlib.py", line 35, in __exit__
        self.gen.throw(type, value, traceback)
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/sandbox.py", line 166, in save_modules
        saved_exc.resume()
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/sandbox.py", line 141, in resume
        six.reraise(type, exc, self._tb)
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/sandbox.py", line 154, in save_modules
        yield saved
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/sandbox.py", line 195, in setup_context
        yield
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/sandbox.py", line 250, in run_setup
        _execfile(setup_script, ns)
      File "/home/travis/build/plone/bobtemplates.plone/.tox/py27-packagetests/lib/python2.7/site-packages/setuptools/sandbox.py", line 45, in _execfile
        exec(code, globals, locals)
      File "/tmp/easy_install-_5oGNO/setuptools_scm-6.0.1/setup.py", line 52, in <module>
    
      File "/tmp/easy_install-_5oGNO/setuptools_scm-6.0.1/setup.py", line 29, in scm_config
        user_options = [
      File "/tmp/easy_install-_5oGNO/setuptools_scm-6.0.1/src/setuptools_scm/__init__.py", line 8, in <module>
      File "/tmp/easy_install-_5oGNO/setuptools_scm-6.0.1/src/setuptools_scm/config.py", line 6, in <module>
      File "/tmp/easy_install-_5oGNO/setuptools_scm-6.0.1/src/setuptools_scm/utils.py", line 41
        print(*k)
              ^
    SyntaxError: invalid syntax
```

when install `pdbpp` on `tox` with Python 2.7. Fix job:

https://travis-ci.org/github/plone/bobtemplates.plone/jobs/744855819

There are still errors in Travis, but at least now they are the same that we have locally.