### PR TITLE
use i18n:domain plone for translations of view/edit action

### DIFF
--- a/bobtemplates/plone/content_type/profiles/default/types/+dexterity_type_fti_file_name+.xml.bob
+++ b/bobtemplates/plone/content_type/profiles/default/types/+dexterity_type_fti_file_name+.xml.bob
@@ -133,6 +133,7 @@
       category="object"
       condition_expr=""
       i18n:attributes="title"
+      i18n:domain="plone"
       title="View"
       url_expr="string:${object_url}"
       visible="True">
@@ -147,6 +148,7 @@
       condition_expr=""
 {{% endif %}}
       i18n:attributes="title"
+      i18n:domain="plone"
       title="Edit"
       url_expr="string:${object_url}/edit"
       visible="True">


### PR DESCRIPTION
Otherwise po files for custom packages will have to unnecessarily translate `View` and `Edit`.