### PR TITLE
Hide all upgrade profiles from site-creation and quickinstaller.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changelog
 - Improve upgrade step template
   [MrTango]
 
+- Hide all upgrade profiles from site-creation and quickinstaller.
+  [thet]
+
 
 6.0b9 (2021-10-23)
 ------------------

--- a/bobtemplates/plone/addon/src/+package.namespace+/+package.name+/setuphandlers.py.bob
+++ b/bobtemplates/plone/addon/src/+package.namespace+/+package.name+/setuphandlers.py.bob
@@ -9,8 +9,12 @@ class HiddenProfiles(object):
     def getNonInstallableProfiles(self):
         """Hide uninstall profile from site-creation and quickinstaller."""
         return [
-            '{{{ package.dottedname }}}:uninstall',
+            "{{{ package.dottedname }}}:uninstall",
         ]
+
+    def getNonInstallableProducts(self):
+        """Hide the upgrades package from site-creation and quickinstaller."""
+        return ["{{{ package.dottedname }}}.upgrades"]
 
 
 def post_install(context):


### PR DESCRIPTION
No need to add individual upgrade steps.

Got this idea from @mauritsvanrees at https://github.com/plone/plone.staticresources/pull/172#pullrequestreview-786149361