### PR TITLE
Mockup pattern template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,11 +21,11 @@ indent_style = space
 # Max Line Length - a hard line wrap, should be disabled
 max_line_length = off
 
-[*.{py,cfg,ini}]
+[*.{py,js,jsx,vue,ts,json,css,scss,cfg,ini}]
 # 4 space indentation
 indent_size = 4
 
-[*.{html,dtml,pt,zpt,xml,zcml,js}]
+[*.{html,dtml,pt,zpt,xml,zcml,yml}]
 # 2 space indentation
 indent_size = 2
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ Vagrantfile
 /venv
 /collective.bob6test*
 /collective.bobtest*
+lib64
+pyvenv.cfg

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 6.0b14 (unreleased)
 -------------------
 
+- Added mockup pattern template.
+  [reinhardt, thet]
+
 - update theme package versions and improve readme
   [MrTango]
 

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -19,3 +19,4 @@ This package was originally based on `bobtemplates.niteoweb <https://github.com/
 - Víctor Fernández de Alba [sneridagh]
 - Alexander Loechel [loechel]
 - Peter Holzer [agitator]
+- Manuel Reinhardt [reinhardt]

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,7 @@ These templates are meant to be used inside a package which was created by the a
 - content_type
 - controlpanel
 - indexer
+- mockup_pattern
 - portlet
 - restapi_service
 - subscriber

--- a/README.rst
+++ b/README.rst
@@ -55,10 +55,12 @@ These templates are meant to be used inside a package which was created by the a
 
 - behavior
 - content_type
+- controlpanel
 - indexer
 - portlet
 - restapi_service
 - subscriber
+- svelte_app
 - theme
 - theme_barceloneta
 - theme_basic

--- a/bobtemplates/plone/bobregistry.py
+++ b/bobtemplates/plone/bobregistry.py
@@ -142,3 +142,11 @@ def plone_controlpanel():
     reg.plonecli_alias = "controlpanel"
     reg.depend_on = "plone_addon"
     return reg
+
+
+def plone_mockup_pattern():
+    reg = RegEntry()
+    reg.template = "bobtemplates.plone:mockup_pattern"
+    reg.plonecli_alias = "mockup_pattern"
+    reg.depend_on = "plone_addon"
+    return reg

--- a/bobtemplates/plone/mockup_pattern.py
+++ b/bobtemplates/plone/mockup_pattern.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+import os
+import re
+
+from bobtemplates.plone.base import base_prepare_renderer
+from bobtemplates.plone.base import echo
+from bobtemplates.plone.base import git_commit
+from bobtemplates.plone.base import git_init
+from mrbob.bobexceptions import ValidationError
+
+
+def pre_render(configurator):
+    """Prepare configuration variables."""
+    configurator = base_prepare_renderer(configurator)
+    configurator.variables["template_id"] = "mockup_pattern"
+
+    bundle_js_path = os.path.join(
+        configurator.variables["package.root_folder"], "resources/bundle.js"
+    )
+    configurator.variables["original_imports"] = ""
+    if os.path.exists(bundle_js_path):
+        with open(bundle_js_path, "r") as bundle_js:
+            configurator.variables["original_imports"] = "\n".join(
+                [
+                    line.strip()
+                    for line in bundle_js.readlines()
+                    if "import" in line and "patternslib" not in line
+                ]
+            )
+
+    configurator.variables["original_body"] = value_from_template(
+        configurator.variables["package.root_folder"],
+        "resources/index.html",
+        r"\<body\>(.*)\<\/body\>",
+    )
+
+    configurator.variables["original_browser_configure"] = value_from_template(
+        configurator.variables["package_folder"],
+        "browser/configure.zcml",
+        r"(\<configure.*)\<\/configure\>",
+    )
+
+    configurator.variables["original_browser_template"] = value_from_template(
+        configurator.variables["package_folder"],
+        "browser/pattern-demo.pt",
+        r"<metal:block define-macro=\"content-core\"\>(.*)\<\/metal:block\>",
+    ) or ""
+
+
+def value_from_template(root_folder, relative_path, regex):
+    path = os.path.join(root_folder, relative_path)
+    if os.path.exists(path):
+        with open(path, "r") as file:
+            # Read the HTML file and extract the body
+            contents = file.read()
+            re_pattern = re.compile(regex, flags=re.DOTALL)
+            return "".join(re_pattern.findall(contents))
+
+
+def post_render(configurator):
+    """Post render script."""
+    root_folder = configurator.variables["package.root_folder"]
+    pattern_name = configurator.variables["pattern.name"]
+    package_name = configurator.variables["package.name"]
+    package_folder_rel_path = configurator.variables["package_folder_rel_path"]
+
+    git_init_status = git_init(configurator)
+    if git_init_status:
+        git_commit(
+            configurator,
+            f"Add pattern: {pattern_name}",
+        )
+    echo(
+        f"""
+Your pattern was added here: {root_folder}/resources/pat-{pattern_name}
+
+Run "npx yarn install" to get the dependencies.
+Run "npx yarn start" to start the development server for developing your pattern.
+Run "npx yarn watch" to re-build the pattern into the Plone environment on changes.
+Run "npx yarn run build" to compile the javascript bundle for production.
+
+Note: You need to build the bundle before you can use the pattern in Plone.
+
+Note: You might want to edit and fix the following file - there might be multiple
+      "{package_name}-pattern-demo" view configurations in it:
+
+.{package_folder_rel_path}/browser/configure.zcml
+
+There is a demo view for your pattern at:
+
+http://localhost:8080/Plone/@@{package_name}-pattern-demo
+
+""",
+        "info",
+    )
+
+
+def post_pattern_name(configurator, question, answer):
+    """Check name."""
+    regex = r"^\w+[a-zA-Z0-9\.\-_]*$"
+    if not re.match(regex, answer):
+        msg = f"""Error: "{answer}" is not a valid pattern name.
+Please use a valid name (like "Autoselect" or "show-hide")!
+At beginning or end only letters|digits are allowed.
+Inside the name ".-_" are also allowed.
+No accents or umlauts."""
+        raise ValidationError(msg)
+    return answer

--- a/bobtemplates/plone/mockup_pattern/.eslintrc.js
+++ b/bobtemplates/plone/mockup_pattern/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require("@patternslib/dev/.eslintrc.js");

--- a/bobtemplates/plone/mockup_pattern/.mrbob.ini
+++ b/bobtemplates/plone/mockup_pattern/.mrbob.ini
@@ -1,0 +1,12 @@
+[questions]
+pattern.name.question = Pattern name (without “pat-” prefix)
+pattern.name.required = True
+pattern.name.default = my-pattern
+pattern.name.help = The name of the pattern. You don't need to specify the “pat-” prefix; it will be added where appropriate.
+pattern.name.pre_ask_question = bobtemplates.plone.base:check_root_folder
+pattern.name.post_ask_question = bobtemplates.plone.mockup_pattern:post_pattern_name
+
+[template]
+pre_render = bobtemplates.plone.mockup_pattern:pre_render
+post_render = bobtemplates.plone.mockup_pattern:post_render
+post_ask = bobtemplates.plone.base:set_global_vars

--- a/bobtemplates/plone/mockup_pattern/.prettierignore
+++ b/bobtemplates/plone/mockup_pattern/.prettierignore
@@ -1,0 +1,2 @@
+*
+!resources/

--- a/bobtemplates/plone/mockup_pattern/.release-it.js
+++ b/bobtemplates/plone/mockup_pattern/.release-it.js
@@ -1,0 +1,1 @@
+module.exports = require("@patternslib/patternslib/.release-it.js");

--- a/bobtemplates/plone/mockup_pattern/babel.config.js
+++ b/bobtemplates/plone/mockup_pattern/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require("@patternslib/patternslib/babel.config.js");

--- a/bobtemplates/plone/mockup_pattern/jest.config.js
+++ b/bobtemplates/plone/mockup_pattern/jest.config.js
@@ -1,0 +1,4 @@
+const jest_config = require("@patternslib/dev/jest.config.js");
+jest_config.rootDir = "./resources";
+
+module.exports = jest_config;

--- a/bobtemplates/plone/mockup_pattern/package.json.bob
+++ b/bobtemplates/plone/mockup_pattern/package.json.bob
@@ -1,0 +1,25 @@
+{
+  "name": "{{{ package.name }}}",
+  "version": "1.0.0",
+  "license": "MIT",
+  "engines": {
+    "node": ">=12.20.0"
+  },
+  "dependencies": {
+    "@patternslib/patternslib": "< 10",
+    "@plone/mockup": "^5.0.0-alpha.21"
+  },
+  "devDependencies": {
+    "@patternslib/dev": "< 3",
+    "yarn": "^1.22.19"
+  },
+  "resolutions": {
+      "@patternslib/patternslib": "< 10",
+      "jquery": "< 4"
+  },
+  "scripts": {
+    "build": "NODE_ENV=production webpack --config webpack.config.js",
+    "start": "NODE_ENV=development webpack serve --config webpack.config.js",
+    "watch": "NODE_ENV=development webpack --config webpack.config.js --watch"
+  }
+}

--- a/bobtemplates/plone/mockup_pattern/prettier.config.js
+++ b/bobtemplates/plone/mockup_pattern/prettier.config.js
@@ -1,0 +1,1 @@
+module.exports = require("@patternslib/dev/prettier.config.js");

--- a/bobtemplates/plone/mockup_pattern/resources/bundle.js.bob
+++ b/bobtemplates/plone/mockup_pattern/resources/bundle.js.bob
@@ -1,0 +1,6 @@
+import registry from "@patternslib/patternslib/src/core/registry";
+
+{{{ original_imports }}}
+import "./pat-{{{ pattern.name }}}/{{{ pattern.name }}}";
+
+registry.init();

--- a/bobtemplates/plone/mockup_pattern/resources/index.html.bob
+++ b/bobtemplates/plone/mockup_pattern/resources/index.html.bob
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>test demo</title>
+    <script src="/{{{ package.name }}}.min.js"></script>
+  </head>
+  <body>{{{ original_body }}}
+    <div class="pat-{{{ pattern.name }}}"></div>
+  </body>
+</html>

--- a/bobtemplates/plone/mockup_pattern/resources/index.js
+++ b/bobtemplates/plone/mockup_pattern/resources/index.js
@@ -1,0 +1,3 @@
+// Webpack entry point for module federation.
+// This import needs to be kept with brackets.
+import("./bundle");

--- a/bobtemplates/plone/mockup_pattern/resources/pat-+pattern.name+/+pattern.name+.js.bob
+++ b/bobtemplates/plone/mockup_pattern/resources/pat-+pattern.name+/+pattern.name+.js.bob
@@ -1,0 +1,28 @@
+import Base from "@patternslib/patternslib/src/core/base";
+import Parser from "@patternslib/patternslib/src/core/parser";
+
+export const parser = new Parser("{{{ pattern.name }}}");
+parser.addArgument("example-option", [1, 2, 3]);
+
+export default Base.extend({
+    name: "{{{ pattern.name }}}",
+    trigger: ".pat-{{{ pattern.name }}}",
+
+    async init() {
+        import("./{{{ pattern.name }}}.scss");
+
+        this.options = parser.parse(this.el, this.options);
+
+        // Just an example!
+        // eslint-disable-next-line no-unused-vars
+        const $ = (await import("jquery")).default; // try to avoid jQuery.
+
+        // Just an example!
+        // eslint-disable-next-line no-unused-vars
+        const example_option = this.options.exampleOption;
+
+        // Just an example!
+        // And completly useless.
+        this.el.innerHTML = `<p>hello from pattern ${this.name}.</p>`;
+    },
+});

--- a/bobtemplates/plone/mockup_pattern/resources/pat-+pattern.name+/+pattern.name+.scss.bob
+++ b/bobtemplates/plone/mockup_pattern/resources/pat-+pattern.name+/+pattern.name+.scss.bob
@@ -1,0 +1,6 @@
+.pat-{{{ pattern.name }}} {
+    // add styles here
+    border: 1px solid green;
+    margin: 1em;
+    padding: 1em;
+}

--- a/bobtemplates/plone/mockup_pattern/src/+package.namespace+/+package.name+/browser/configure.zcml.bob
+++ b/bobtemplates/plone/mockup_pattern/src/+package.namespace+/+package.name+/browser/configure.zcml.bob
@@ -1,0 +1,10 @@
+{{{ original_browser_configure }}}
+
+  <browser:page
+      name="{{{ package.name }}}-pattern-demo"
+      for="*"
+      template="pattern-demo.pt"
+      permission="zope2.View"
+      />
+
+</configure>

--- a/bobtemplates/plone/mockup_pattern/src/+package.namespace+/+package.name+/browser/pattern-demo.pt.bob
+++ b/bobtemplates/plone/mockup_pattern/src/+package.namespace+/+package.name+/browser/pattern-demo.pt.bob
@@ -1,0 +1,17 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+    xmlns:tal="http://xml.zope.org/namespaces/tal"
+    xmlns:metal="http://xml.zope.org/namespaces/metal"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    lang="en"
+    metal:use-macro="context/@@main_template/macros/master"
+    i18n:domain="{{{ package.name }}}">
+<body>
+
+<metal:content-core fill-slot="content-core">
+<metal:block define-macro="content-core">{{{ original_browser_template }}}
+  <div class="pat-{{{ pattern.name }}}"></div>
+</metal:block>
+</metal:content-core>
+
+</body>
+</html>

--- a/bobtemplates/plone/mockup_pattern/src/+package.namespace+/+package.name+/browser/static/bundles/.gitkeep
+++ b/bobtemplates/plone/mockup_pattern/src/+package.namespace+/+package.name+/browser/static/bundles/.gitkeep
@@ -1,0 +1,1 @@
+# let git keep this directory, even if the bundle wasn't built yet.

--- a/bobtemplates/plone/mockup_pattern/src/+package.namespace+/+package.name+/profiles/default/registry/bundles.xml.bob
+++ b/bobtemplates/plone/mockup_pattern/src/+package.namespace+/+package.name+/profiles/default/registry/bundles.xml.bob
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<registry>
+
+  <records
+      interface="Products.CMFPlone.interfaces.IBundleRegistry"
+      prefix="plone.bundles/{{{ package.name }}}">
+    <value key="enabled">True</value>
+    <value key="jscompilation">++plone++{{{ package.namespace }}}.{{{ package.name }}}/bundles/{{{ package.name }}}-remote.min.js</value>
+  </records>
+
+</registry>

--- a/bobtemplates/plone/mockup_pattern/src/+package.namespace+/+package.name+/profiles/uninstall/registry/bundles.xml.bob
+++ b/bobtemplates/plone/mockup_pattern/src/+package.namespace+/+package.name+/profiles/uninstall/registry/bundles.xml.bob
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<registry>
+  <records
+      interface="Products.CMFPlone.interfaces.IBundleRegistry"
+      prefix="plone.bundles/{{{ package.name }}}"
+      remove="true"
+      />
+</registry>

--- a/bobtemplates/plone/mockup_pattern/webpack.config.js.bob
+++ b/bobtemplates/plone/mockup_pattern/webpack.config.js.bob
@@ -1,0 +1,43 @@
+process.traceDeprecation = true;
+const mf_config = require("@patternslib/dev/webpack/webpack.mf");
+const package_json = require("./package.json");
+const package_json_mockup = require("@plone/mockup/package.json");
+const package_json_patternslib = require("@patternslib/patternslib/package.json");
+const path = require("path");
+const webpack_config = require("@patternslib/dev/webpack/webpack.config").config;
+
+module.exports = () => {
+    let config = {
+        entry: {
+            "{{{ package.name }}}.min": path.resolve(__dirname, "resources/index.js"),
+        },
+    };
+
+    config = webpack_config({
+        config: config,
+        package_json: package_json,
+    });
+    config.output.path = path.resolve(__dirname, "src/{{{ package.namespace }}}/{{{ package.name }}}/browser/static/bundles");
+
+    config.plugins.push(
+        mf_config({
+            name: "{{{ package.name }}}",
+            filename: "{{{ package.name }}}-remote.min.js",
+            remote_entry: config.entry["{{{ package.name }}}.min"],
+            dependencies: {
+                ...package_json_patternslib.dependencies,
+                ...package_json_mockup.dependencies,
+                ...package_json.dependencies,
+            },
+        })
+    );
+
+    if (process.env.NODE_ENV === "development") {
+        config.devServer.port = "3001";
+        config.devServer.static.directory = path.resolve(__dirname, "./resources/");
+    }
+
+    // console.log(JSON.stringify(config, null, 4));
+
+    return config;
+};

--- a/package_tests/test_mockup_pattern.py
+++ b/package_tests/test_mockup_pattern.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+import os
+
+import pytest
+from mrbob.bobexceptions import ValidationError
+from mrbob.configurator import Configurator
+
+from bobtemplates.plone import base, mockup_pattern
+
+from .base import init_package_base_structure
+
+
+def test_pre_render(tmpdir):
+    package_root = tmpdir.strpath + "/collective.testpattern"
+    package_path = init_package_base_structure(package_root)
+
+    configurator = Configurator(
+        template="bobtemplates.plone:mockup_pattern",
+        target_directory=package_path,
+        variables={
+            "pattern.name": "test-pattern",
+        },
+    )
+    mockup_pattern.pre_render(configurator)
+
+    assert configurator.variables["template_id"] == "mockup_pattern"
+    assert configurator.variables["pattern.name"] == "test-pattern"
+    assert configurator.target_directory.endswith("collective.testpattern")
+
+
+def test_post_render(tmpdir):
+    package_root = tmpdir.strpath + "/collective.testpattern"
+    package_path = init_package_base_structure(package_root)
+
+    configurator = Configurator(
+        template="bobtemplates.plone:mockup_pattern",
+        target_directory=package_path,
+        bobconfig={"non_interactive": True},
+        variables={
+            "plone.version": "6.0",
+            "pattern.name": "test-pattern",
+        },
+    )
+    configurator = Configurator(
+        template="bobtemplates.plone:theme_barceloneta",
+        target_directory=package_path,
+        bobconfig={"non_interactive": True},
+        variables={"plone.version": "5.1", "theme.name": "My Theme"},
+    )
+
+    assert configurator
+    os.chdir(package_path)
+    base.set_global_vars(configurator)
+    configurator.render()  # pre/render/post
+
+
+def test_post_pattern_name(tmpdir):
+    """Verifies that pattern names are checked for validity."""
+    target_path = tmpdir.strpath + "/collective.testpattern"
+    configurator = Configurator(
+        template="bobtemplates.plone:mockup_pattern", target_directory=target_path
+    )
+
+    mockup_pattern.post_pattern_name(configurator, None, "test-pattern")
+    with pytest.raises(ValidationError):
+        mockup_pattern.post_pattern_name(configurator, None, "test.$SPAM")

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
             "plone_buildout = bobtemplates.plone.bobregistry:plone_buildout",
             "plone_content_type = bobtemplates.plone.bobregistry:plone_content_type",
             "plone_indexer = bobtemplates.plone.bobregistry:plone_indexer",
+            "plone_mockup_pattern = bobtemplates.plone.bobregistry:plone_mockup_pattern",
             "plone_portlet = bobtemplates.plone.bobregistry:plone_portlet",
             "plone_restapi_service = bobtemplates.plone.bobregistry:plone_restapi_service",  # NOQA E501
             "plone_svelte_app = bobtemplates.plone.bobregistry:plone_svelte_app",

--- a/skeleton-tests/test_addon_mockup_pattern.py
+++ b/skeleton-tests/test_addon_mockup_pattern.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+import os
+import re
+
+from base import file_exists, generate_answers_ini, run_skeleton_tox_env
+from mrbob.cli import main
+
+
+def test_addon_pattern(tmpdir, capsys, config):
+    answers_ini_path = os.path.join(tmpdir.strpath, "answers.ini")
+    package_dir = os.path.abspath(tmpdir.strpath)
+    template = """[variables]
+package.description = Pattern Test Package
+package.git.disabled = True
+
+author.name = The Plone Collective
+author.email = collective@plone.org
+author.github.user = collective
+subtemplate_warning=False
+
+plone.version = {version}
+""".format(
+        version=config.version
+    )
+    generate_answers_ini(package_dir, template)
+
+    # generate template addon:
+    config.template = "addon"
+    config.package_name = "collective.testpattern"
+
+    wd = os.path.abspath(os.path.join(tmpdir.strpath, config.package_name))
+    main(
+        [
+            "-O",
+            config.package_name,
+            "bobtemplates.plone:" + config.template,
+            "--config",
+            answers_ini_path,
+            "--non-interactive",
+            "--target-directory",
+            wd,
+        ],
+    )
+
+    # generate subtemplate content_type:
+    template = """[variables]
+pattern.name = test-pattern
+subtemplate_warning=False
+"""
+    generate_answers_ini(package_dir, template)
+
+    config.template = "mockup_pattern"
+    main(
+        [
+            "bobtemplates.plone:" + config.template,
+            "--config",
+            answers_ini_path,
+            "--non-interactive",
+            "--target-directory",
+            wd,
+        ],
+    )
+
+    assert file_exists(wd, "/package.json")
+    assert file_exists(wd, "/webpack.config.js")
+    assert file_exists(
+        wd,
+        "/src/collective/testpattern/profiles/default/registry/bundles.xml",
+    )
+    found_jscompilation = False
+    with open(
+        f"{wd}/src/collective/testpattern/profiles/default/registry/bundles.xml", "r"
+    ) as bundles_file:
+        for line in bundles_file.readlines():
+            if "jscompilation" in line:
+                value = re.search(r">([^<]*)", line)[1]
+                assert value == (
+                    "++plone++collective.testpattern/bundles/"
+                    "testpattern-remote.min.js"
+                )
+                found_jscompilation = True
+    assert found_jscompilation
+
+    with capsys.disabled():
+        run_skeleton_tox_env(wd, config)

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
     py{38,37}-skeletontests-Plone{52}-template-addon_all
     py{39}-skeletontests-Plone{60}-template-addon_all
     py{39}-skeletontests-Plone{60}-template-addon_theme_barceoneta
+    py{38,39}-skeletontests-Plone{60}-template-addon_mockup_pattern
     coverage-report,
 
 skip_missing_interpreters = True
@@ -36,6 +37,7 @@ commands =
     template-addon: pytest skeleton-tests/test_addon.py {posargs}
     template-addon_all: pytest skeleton-tests/test_addon_all.py {posargs}
     template-addon_theme_barceoneta: pytest skeleton-tests/test_addon_theme_barceloneta.py {posargs}
+    template-addon_mockup_pattern: pytest skeleton-tests/test_addon_mockup_pattern.py {posargs}
 
 setenv =
     COVERAGE_FILE=.coverage.{envname}


### PR DESCRIPTION
This adds a new template `mockup_pattern`. It can be applied multiple times, resulting in multiple patterns in `resources`. All patterns are combined into a single bundle. For this purpose the `pre_render()` method keeps the existing imports if bundle.js already exists.

Replaces #507 

Most notable changes to #507
- Path for new patterns is ``resources/pat-NEW_PATTERN``. Any extra JavaScript / SCSS‌ / etc which needs extra compilation steps via Webpack or whatever should go into there.
- Removed the extra CSS compilation scripts from package.json and CSS integration. Instead any SCSS code should be imported in the Pattern itself, which will then only be used if the pattern is loaded. Other CSS is theming stuff. We might need another CSS‌ compilation step for the addon package itself, but that is slightly out of scope of the mockup pattern integration and should be added as another template which writes into the ``resources/`` folder.
- Changed compiled production paths from ``pattern`` to ``bundle``
- Register the bundle for all users - not only for logged-in
- Simplified the package.json scripts. We only need to ``serve``, ``watch`` and ``build``.
- Aligned code with latest https://github.com/Patternslib/pat-PATTERN_TEMPLATE
- Updating entry point init.js for latest module federation support.
- Updated package.json to fetch latest packages without the need to explicitly specify the versions.
- Added a demo file.

