### PR TITLE
replace backslash with os.path.sep

### DIFF
--- a/bobtemplates/plone/base.py
+++ b/bobtemplates/plone/base.py
@@ -434,7 +434,7 @@ def base_prepare_renderer(configurator):
         raise MrBobError("No setup.py found in path!\n")
     configurator.variables["package.dottedname"] = configurator.variables[
         "package.root_folder"
-    ].split("/")[-1]
+    ].split(os.path.sep)[-1]
     configurator.variables["package.namespace"] = configurator.variables[
         "package.dottedname"
     ].split(".")[0]


### PR DESCRIPTION
Fixes [Issue#531](https://github.com/plone/bobtemplates.plone/issues/531)