### PR TITLE
Remove effbot.org/downloads from find-links

### DIFF
--- a/bobtemplates/plone/buildout/base.cfg.bob
+++ b/bobtemplates/plone/buildout/base.cfg.bob
@@ -28,7 +28,6 @@ versions = versions
 # of Plone packages.
 find-links =
     http://dist.plone.org
-    http://effbot.org/downloads
 
 ############################################
 # Environment Variables


### PR DESCRIPTION
No longer online. Fredrik Lundh passed away in 2021.  IIRC this was added for some special packages needed for Plone 3 & 4. Nowadays everything is on PyPI.