### PR TITLE
fixed the msg in view , added tal:content=view/msg expression in the …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+6.2.7 (2023-03-05)
+------------------
+
+- fixed the msg in view , added tal:content="view/msg" expression in the <p> tag that will call the msg
+  [Coder-aadarsh]
+
+
 6.2.6 (unreleased)
 ------------------
 

--- a/bobtemplates/plone/view/views/+view_python_file_name+.py.bob
+++ b/bobtemplates/plone/view/views/+view_python_file_name+.py.bob
@@ -35,6 +35,10 @@ class {{{ view_python_class_name }}}({{{ view_base_class }}}):
 {{% else %}}
         return self.index()
 {{% endif %}}
+
+    def msg(self):
+        return "msg from '{}".format(self.__class__.__name__)
+
 {{% else %}}
     def __call__(self):
         template = '''<li class="heading" i18n:translate="">

--- a/bobtemplates/plone/view/views/+view_template_name+.pt.bob
+++ b/bobtemplates/plone/view/views/+view_template_name+.pt.bob
@@ -26,6 +26,7 @@
   <metal:block define-macro="content-core">
 
     <h2>Main content</h2>
+    <p tal:content="view/msg">this gets replaced</p>
     <!--<div tal:replace="view/my_custom_view_method" />-->
     <!--<div tal:replace="context/my_custom_field" />-->
 


### PR DESCRIPTION
As suggested by @me-kell in issue - [Add a msg funtion to the view python class (e.g. as follows): #496](https://github.com/plone/bobtemplates.plone/issues/496#issue-1126304458)
Modified code so that - 
The msg function returns a string that includes the name of the view class; and the template file using tal:content="view/msg" expression in the <p> tag will call the msg function in the view and display the returned string on the page.
