### PR TITLE
Fix the GitLab CI cache for pip.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 6.2.6 (unreleased)
 ------------------
 
+- Fix the GitLab CI cache for pip.
+  [thet]
+
 - mockup_pattern: Fix .prettierignore file to not exclude files within the /resources directory.
   [thet]
 

--- a/bobtemplates/plone/addon/.gitlab-ci.yml
+++ b/bobtemplates/plone/addon/.gitlab-ci.yml
@@ -6,7 +6,7 @@ image: python:3.7-buster
 # Change pip's cache directory to be inside the project directory since we can
 # only cache local items.
 variables:
-  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache"
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
 
 # Pip's cache doesn't store the python packages
 # https://pip.pypa.io/en/stable/reference/pip_install/#caching


### PR DESCRIPTION
The pip cache dir is normally:
PIP_CACHE_DIR = XDG_CACHE_HOME + /pip
This commit fixes the PIP_CACHE_DIR to be in the local project .cache/pip subdirectory. Also see: https://gitlab.com/gitlab-org/gitlab-foss/-/merge_requests/22211