### PR TITLE
allow overriding package.dottedname through a configuration file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 6.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow overriding package.dottedname in the configuration file
+  [erral]
 
 
 6.3.3 (2024-07-31)

--- a/bobtemplates/plone/base.py
+++ b/bobtemplates/plone/base.py
@@ -432,9 +432,12 @@ def base_prepare_renderer(configurator):
     )
     if not configurator.variables["package.root_folder"]:
         raise MrBobError("No setup.py found in path!\n")
-    configurator.variables["package.dottedname"] = configurator.variables[
-        "package.root_folder"
-    ].split(os.path.sep)[-1]
+
+    if "package.dottedname" not in configurator.variables:
+        configurator.variables["package.dottedname"] = configurator.variables[
+            "package.root_folder"
+        ].split(os.path.sep)[-1]
+
     configurator.variables["package.namespace"] = configurator.variables[
         "package.dottedname"
     ].split(".")[0]


### PR DESCRIPTION
Useful to be able to override some settings when creating packages, such as when using from cookieplone to create Plone  projects.

see https://github.com/plone/cookieplone-templates/pull/63