### PR TITLE
fix test-coverage bash script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 6.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- fix test-coverage bash script, so that it will fail if the tests fail
+  [mamico]
 
 
 6.3.3 (2024-07-31)

--- a/bobtemplates/plone/addon/base.cfg.bob
+++ b/bobtemplates/plone/addon/base.cfg.bob
@@ -69,6 +69,7 @@ eggs = coverage
 recipe = collective.recipe.template
 input = inline:
     #!/bin/bash
+    set -e
     export TZ=UTC
     ${buildout:directory}/bin/coverage run bin/test $*
     ${buildout:directory}/bin/coverage html


### PR DESCRIPTION
as it is now, in my tests, the bash script never fails, so using bin/test-coverage in an CI never shows broken tests