### PR TITLE
Honor "package.git.autocommit" variable

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,8 @@
 root = true
 
 
-[*]  # For All Files
+[*]
+# For All Files
 # Unix-style newlines with a newline ending every file
 end_of_line = lf
 insert_final_newline = true

--- a/bobtemplates/plone/base.py
+++ b/bobtemplates/plone/base.py
@@ -117,28 +117,32 @@ def git_init(configurator):
 def git_commit(configurator, msg):
     if not git_support(configurator):
         return
-    non_interactive = configurator.bobconfig.get("non_interactive")
     working_dir = (
         configurator.variables.get("package.root_folder")
         or configurator.target_directory
     )
     params1 = ["git", "add", "."]
     params2 = ["git", "commit", "-m", '"{0}"'.format(msg)]
-    git_autocommit = None
-    run_git_commit = True
-    autocommit_flag = configurator.variables.get("package.git.autocommit", "False")
-    if hooks.to_boolean(None, None, autocommit_flag):
-        git_autocommit = True
-    if not non_interactive and not git_autocommit:
-        echo(
-            "Should we run?:\n{0}\n{1}\nin: {2}".format(
-                " ".join(params1), " ".join(params2), working_dir
-            ),
-            "info",
-        )
-        run_git_commit = (input("[y]/n: ") or "y").lower() == "y"
+    variable = "package.git.autocommit"
+    if variable in configurator.variables:
+        # The operator requested a certain behavior,
+        # we should oblige, irrespective of interactive/non-interactive
+        run_git_commit = hooks.to_boolean(None, None, configurator.variables.get(variable))
+    else:
+        # no indication from the operator: now we ask only if in interactive mode
+        non_interactive = configurator.bobconfig.get("non_interactive")
+        if non_interactive:
+            run_git_commit = True
+        else:
+            echo(
+                "Should we run?:\n{0}\n{1}\nin: {2}".format(
+                    " ".join(params1), " ".join(params2), working_dir
+                ),
+                "info",
+            )
+            run_git_commit = (input("[y]/n: ") or "y").lower() == "y"
 
-    if not run_git_commit and not git_autocommit:
+    if not run_git_commit:
         echo("Skip git commit!", "warning")
         return
 


### PR DESCRIPTION
I think that, when in interactive mode, whatever I write for "package.git.autocommit" in my config file is not taken in consideration.

This PR should fix this behavior and aim at
- always honoring the provided variable
- ask only if nothing was provided and we are in "interactive" mode


I've manually tested as follows:
- `cd` to a plone add-on folder
- call `mrbob bobtemplates.plone:content_type -c config.mrbob` with and without the `--non-interactive` switch
- in the config file, set `package.git.autocommit` to `y`, to `n`, or do not set it (see below)

```
[variables]

# package.git.autocommit = y

author.name = Me
author.email = me@example.com
author.github.user = me
package.description = any
package.git.init = n
subtemplate_warning = y
dexterity_type_name = any
dexterity_type_desc = any
dexterity_type_icon_expr = tencent-qq
dexterity_type_supermodel = n
dexterity_type_base_class = Container
dexterity_type_global_allow = y
dexterity_type_filter_content_types = n
dexterity_type_create_class = y
dexterity_type_activate_default_behaviors = y
```

[Off-Topic] AFAICT, comments in the `.editorconfig` file should go on their line (my IDE complained and it's probably right :slightly_smiling_face: )
https://editorconfig.org/#file-format-details

HTH

P.S. thanks for the good work!
