### PR TITLE
fix: check that package_dottedname is not None before setting it

### DIFF
--- a/bobtemplates/plone/base.py
+++ b/bobtemplates/plone/base.py
@@ -229,7 +229,7 @@ def set_global_vars(configurator):
         version = bob_config.version
     configurator.variables["plone.version"] = version
     set_plone_version_variables(configurator)
-    if hasattr(bob_config, "package_dottedname"):
+    if hasattr(bob_config, "package_dottedname") and bob_config.package_dottedname:
         configurator.variables["package.dottedname"] = bob_config.package_dottedname
 
 


### PR DESCRIPTION
We have a default value of `None` for package_dottedname in the BobConfig class, so we need to check here whether the value is not None to override the value of package.dottedname variable, otherwise it is set to be `None` and fails.