### PR TITLE
Fix broken documentation links in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -209,7 +209,7 @@ Contribute
 
 - Issue Tracker: https://github.com/plone/bobtemplates.plone/issues
 - Source Code: https://github.com/plone/bobtemplates.plone
-- Documentation: https://docs.plone.org/develop/addons/bobtemplates.plone/docs/ or https://bobtemplatesplone.readthedocs.io/en/latest/
+- Documentation: https://5.docs.plone.org/develop/addons/bobtemplates.plone/bobtemplates.plone/docs/ or https://bobtemplatesplone.readthedocs.io/
 
 
 Support


### PR DESCRIPTION
- Replaced https://docs.plone.org/develop/addons/bobtemplates.plone/docs/
  with https://5.docs.plone.org/develop/addons/bobtemplates.plone/bobtemplates.plone/docs/

- Replaced https://bobtemplatesplone.readthedocs.io/en/latest/
  with https://bobtemplatesplone.readthedocs.io/

These changes ensure users land on working documentation pages.

